### PR TITLE
[#20] Adding rounded button template

### DIFF
--- a/app/src/main/res/color/rounded_corner_blue_btn_selector.xml
+++ b/app/src/main/res/color/rounded_corner_blue_btn_selector.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false"
+          android:color="@color/colorButtonDisable"/>
+
+    <item android:state_pressed="true"
+          android:color="@color/colorButtonPressed"/>
+
+    <item android:color="@color/colorButtonEnable"/>
+</selector>

--- a/app/src/main/res/drawable/rounded_corner_blue_btn_bg.xml
+++ b/app/src/main/res/drawable/rounded_corner_blue_btn_bg.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle">
+    <corners android:radius="40dp"/>
+    <solid android:color="@color/rounded_corner_blue_btn_selector"/>
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -42,24 +42,39 @@
             app:layout_constraintTop_toBottomOf="@id/imageView"/>
 
         <Button
+            style="@style/Widget.Template.Button"
             android:id="@+id/buttonRefresh"
             android:layout_width="120dp"
-            android:layout_height="50dp"
-            android:layout_marginTop="5dp"
+            android:layout_height="45dp"
+            android:layout_marginTop="15dp"
             android:text="Refresh"
             app:layout_constraintEnd_toStartOf="@id/buttonNext"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/imageView"/>
 
         <Button
+            style="@style/Widget.Template.Button"
             android:id="@+id/buttonNext"
             android:layout_width="120dp"
-            android:layout_height="50dp"
-            android:layout_marginTop="5dp"
+            android:layout_height="45dp"
+            android:layout_marginTop="15dp"
             android:text="Next"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/buttonRefresh"
             app:layout_constraintTop_toBottomOf="@id/imageView"/>
+
+        <Button
+            style="@style/Widget.Template.Button"
+            android:id="@+id/buttonDisabled"
+            android:layout_width="120dp"
+            android:layout_height="45dp"
+            android:layout_marginTop="15dp"
+            android:enabled="false"
+            android:text="Disabled"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/buttonRefresh"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
 
         <TextView
             style="@style/Widget.Template.TextView.Clickable"
@@ -70,7 +85,7 @@
             android:padding="15dp"
             android:text="Clickable text"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/buttonRefresh"
+            app:layout_constraintTop_toBottomOf="@id/buttonDisabled"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"/>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,4 +4,11 @@
     <color name="colorPrimary">@color/light_blue</color>
     <color name="colorPrimaryDark">@color/dark_blue</color>
     <color name="colorAccent">@color/pink</color>
+
+    <color name="colorButtonText">@color/white</color>
+    <color name="colorButtonDisable">@color/black_40a</color>
+    <color name="colorButtonEnable">@color/light_blue</color>
+    <color name="colorButtonPressed">@color/dark_blue</color>
+
+
 </resources>

--- a/app/src/main/res/values/colors_pallete.xml
+++ b/app/src/main/res/values/colors_pallete.xml
@@ -13,4 +13,6 @@
 
     <color name="black">#000000</color>
     <color name="black_20a">#20000000</color>
+    <color name="black_40a">#40000000</color>
+
 </resources>

--- a/app/src/main/res/values/dimens_text.xml
+++ b/app/src/main/res/values/dimens_text.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="dimen_normal_display_text">14sp</dimen>
+
+    <dimen name="dimen_normal_button_text">15sp</dimen>
 </resources>

--- a/app/src/main/res/values/widget_styles.xml
+++ b/app/src/main/res/values/widget_styles.xml
@@ -16,4 +16,13 @@
         <item name="android:focusable">true</item>
         <item name="android:background">?android:attr/selectableItemBackground</item>
     </style>
+
+    <style name="Widget.Template.Button" parent="Widget.AppCompat.Button.Colored">
+        <item name="android:fontFamily">@font/circularstd_bold</item>
+        <item name="android:textColor">@color/colorButtonText</item>
+        <item name="android:background">@drawable/rounded_corner_blue_btn_bg</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textSize">@dimen/dimen_normal_button_text</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## What happened 🤔
Add a common use rounded corner button with material design theming inheritance.

## Insight 👀
- Support custom font text, styling is reusable and adjustable.
- Support state: normal | pressed | disable
- **TO USE THIS WIDGET:**
   - Merge this branch `feature/rounded-button`
   - Using `Widget.Template.TextView.Bold` for your button `style` attribute.
   - Customizable options:
         - Customize the rounded radius in `rounded_corner_blue_btn_bg.xml`
         - Text style/coloring is accessible via `widget_style.xml` -> `Widget.Template.Button`

## PoW (a.k.a Proof Of Work)💪
Voila!
<img src="https://user-images.githubusercontent.com/13435717/41585346-fcba61ba-73d3-11e8-8b0a-d5d1a474da37.png" width=200 /> 