### PR TITLE
[#22] Adding a simple Custom Dialog

### DIFF
--- a/app/src/main/java/com/nimbl3/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/nimbl3/ui/main/MainActivity.kt
@@ -3,6 +3,7 @@ package com.nimbl3
 import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
+import android.support.v4.app.DialogFragment
 import android.view.View.*
 import com.jakewharton.rxbinding2.view.RxView
 import com.nimbl3.data.lib.schedulers.SchedulersProvider
@@ -12,10 +13,12 @@ import com.nimbl3.ui.base.BaseActivity
 import com.nimbl3.ui.main.MainViewModel
 import com.nimbl3.ui.main.data.Data
 import com.nimbl3.ui.second.SecondActivity
+import com.nimbl3.ui.widget.ConfirmationDialogFragment
+import com.nimbl3.ui.widget.ConfirmationDialogFragment.ConfirmationDialogListener
 import kotlinx.android.synthetic.main.activity_main.*
 import javax.inject.Inject
 
-class MainActivity : BaseActivity() {
+class MainActivity : BaseActivity(), ConfirmationDialogListener{
 
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var schedulers: SchedulersProvider
@@ -61,6 +64,14 @@ class MainActivity : BaseActivity() {
         RxView.clicks(buttonNext)
             .subscribe { viewModel.inputs.next()}
             .bindForDisposable()
+
+        RxView.clicks(buttonShowDialog)
+            .subscribe {
+                // TODO: Bind this to ViewModel CTA, DO NOT resolve the action directly
+                ConfirmationDialogFragment()
+                    .show(supportFragmentManager, ConfirmationDialogFragment.TAG)
+            }
+            .bindForDisposable()
     }
 
     private fun bindData(data: Data) {
@@ -75,5 +86,16 @@ class MainActivity : BaseActivity() {
 
     private fun gotoNextScreen(data: Data) {
         SecondActivity.show(this, data)
+    }
+
+    override fun onDialogPositiveClick(dialog: DialogFragment) {
+        // TODO: Bind this to ViewModel CTA, DO NOT resolve the action directly
+    }
+
+    override fun onDialogNegativeClick(dialog: DialogFragment) {
+        // TODO: Bind this to ViewModel CTA, DO NOT resolve the action directly
+        val dialog = supportFragmentManager
+            .findFragmentByTag(ConfirmationDialogFragment.TAG) as ConfirmationDialogFragment
+        dialog.dismiss()
     }
 }

--- a/app/src/main/java/com/nimbl3/ui/widget/ConfirmationDialogFragment.kt
+++ b/app/src/main/java/com/nimbl3/ui/widget/ConfirmationDialogFragment.kt
@@ -1,0 +1,43 @@
+package com.nimbl3.ui.widget
+
+import android.os.Bundle
+import android.support.v4.app.DialogFragment
+import android.view.LayoutInflater
+import com.nimbl3.R
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.dialog_confirmation.view.*
+
+
+class ConfirmationDialogFragment : DialogFragment() {
+
+    interface ConfirmationDialogListener {
+        fun onDialogPositiveClick(dialog: DialogFragment)
+        fun onDialogNegativeClick(dialog: DialogFragment)
+    }
+
+    lateinit var mListener: ConfirmationDialogListener
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val view =  inflater.inflate(R.layout.dialog_confirmation, container, false)
+
+        view.btnDialogOk.setOnClickListener { mListener.onDialogPositiveClick(this) }
+        view.btnDialogCancel.setOnClickListener { mListener.onDialogNegativeClick(this) }
+
+        return view
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        try {
+            mListener = context as ConfirmationDialogListener
+        } catch (e: ClassCastException) {
+            throw ClassCastException(context.toString() + " must implement NoticeDialogListener")
+        }
+    }
+
+    companion object {
+        const val TAG = "CONFIRMATION_DIALOG_FRAGMENT_TAG"
+    }
+}

--- a/app/src/main/res/drawable/rounded_alert_dialog_bg.xml
+++ b/app/src/main/res/drawable/rounded_alert_dialog_bg.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item>
+    <shape>
+      <corners android:radius="20dp"/>
+      <solid android:color="@color/white" />
+    </shape>
+  </item>
+</selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -63,12 +63,13 @@
 
         <TextView
             style="@style/Widget.Template.TextView.Clickable"
+            android:id="@+id/buttonShowDialog"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
             android:layout_marginTop="@dimen/dimen_normal_display_text"
             android:padding="15dp"
-            android:text="Clickable text"
+            android:text="Show Dialog"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/buttonRefresh"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/dialog_confirmation.xml
+++ b/app/src/main/res/layout/dialog_confirmation.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="360dp"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:background="@drawable/rounded_alert_dialog_bg"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/tvConfirmDialogMessage"
+        style="@style/Widget.Template.TextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:lineSpacingMultiplier="1.4"
+        android:paddingBottom="32dp"
+        android:paddingEnd="22dp"
+        android:paddingStart="22dp"
+        android:paddingTop="38dp"
+        android:text="Are you sure you want to do this? \n Please confirm"/>
+
+    <include
+        layout="@layout/light_gray_line"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/btnDialogOk"
+            style="@style/Widget.Template.TextView.Clickable"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.5"
+            android:gravity="center"
+            android:padding="15dp"
+            android:text="@string/general_ok"/>
+
+        <include
+            layout="@layout/light_gray_line"
+            android:layout_width="1dp"
+            android:layout_height="match_parent"/>
+
+        <TextView
+            android:id="@+id/btnDialogCancel"
+            style="@style/Widget.Template.TextView.Clickable"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.5"
+            android:gravity="center"
+            android:padding="15dp"
+            android:text="@string/general_cancel"/>
+    </LinearLayout>
+
+
+</LinearLayout>

--- a/app/src/main/res/layout/light_gray_line.xml
+++ b/app/src/main/res/layout/light_gray_line.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<View xmlns:android="http://schemas.android.com/apk/res/android"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:background="@color/black_20a"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Nimbl3 Template</string>
+    <string name="general_ok">OK</string>
+    <string name="general_cancel">Cancel</string>
 </resources>


### PR DESCRIPTION
## What happened 🤔
Adding a simple Confirmation Dialog Fragment that meets the requirements #22

## Insight 👀
- Extending from DialogFragment and surviving the orientation change. The implementation is naive, but yet provided callbacks for interaction and basic implementation. 
- **TO USE THIS COMPONENTS:**
   - Merge this branch and start using the `ConfirmationDialogFragment` and passing a SupportFragmentManager to it with a tag (for retrieval purpose after).
   - Customizing the options can be done within the `ConfirmationDialogFragment`
   - The implementation isn't mapped to the ViewModel yet because I don't want it to be too complex that could produce complexity with merge conflicts later.

## PoW (a.k.a Proof Of Work)💪
<img src="https://user-images.githubusercontent.com/13435717/41594572-fa343b68-73ed-11e8-80f2-aca547a3f049.png" width=200 /> <img src="https://user-images.githubusercontent.com/13435717/41594730-9a7268b6-73ee-11e8-92f5-10c13505948b.png" width=400 /> 