### PR TITLE
Update java byte code classes path for jacoco

### DIFF
--- a/config/jacoco.gradle
+++ b/config/jacoco.gradle
@@ -29,7 +29,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: "testStagingDebugUnitTest")
     def fileFilter = fileGenerated + packagesExcluded
 
     classDirectories = fileTree(
-        dir: "$buildDir/intermediates/classes/staging/debug",
+        dir: "$buildDir/intermediates/javac/stagingDebug/compileStagingDebugJavaWithJavac/classes",
         excludes: fileFilter
     ) + fileTree(
         dir: "$buildDir/tmp/kotlin-classes/stagingDebug",

--- a/config/jacoco.gradle
+++ b/config/jacoco.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.1"
+    toolVersion = "0.8.3"
     reportsDir = file("$buildDir/reports/jacoco")
 }
 


### PR DESCRIPTION
## What happened 🤔
Jacoco doesn't report for java classes, coverage is higher than expected https://stackoverflow.com/questions/53374692/android-java-byte-code-missing-after-update-gradle-and-build-tools


## Insight 👀
- Java Byte Code (generated .class files) is under `$buildDir/intermediates/javac/developerDebug/compileDeveloperDebugJavaWithJavac/classes` instead after upgrated gradle https://stackoverflow.com/questions/53374692/android-java-byte-code-missing-after-update-gradle-and-build-tools
