### PR TITLE
Update jacoco report

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,8 +3,8 @@ apply from: 'codequality.gradle'
 apply from: '../config/jacoco.gradle'
 
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'kotlin-android-extensions'
 
 def keystorePropertiesFile = rootProject.file("signing.properties")
 def keystoreProperties = new Properties()

--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,6 @@ buildscript {
         android_target_sdk_version = 28
         android_compile_sdk_version = 28
 
-        jacoco_core_version = "0.8.5"
-        jacoco_android_plugin_version = '0.1.4'
-
         // Dependencies (Alphabet sorted)
         android_legacy_support_version = '1.0.0'
         android_support_version     = '1.1.0-alpha01'
@@ -56,7 +53,6 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:$build_gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.dicedmelon.gradle:jacoco-android:$jacoco_android_plugin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,16 @@
 
 buildscript {
     ext {
+        build_gradle_version = '3.6.1'
+
         android_version_code = 1
         android_version_name = "0.1.0"
         android_min_sdk_version = 19
         android_target_sdk_version = 28
         android_compile_sdk_version = 28
+
+        jacoco_core_version = "0.8.5"
+        jacoco_android_plugin_version = '0.1.4'
 
         // Dependencies (Alphabet sorted)
         android_legacy_support_version = '1.0.0'
@@ -22,7 +27,7 @@ buildscript {
         glide_version               = '4.8.0'
         gson_version                = '2.4'
 
-        kotlin_version              = '1.3.11'
+        kotlin_version              = '1.3.61'
 
         moshi_version               = '1.6.0'
         multidex_version            = '2.0.1'
@@ -49,9 +54,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath "com.android.tools.build:gradle:$build_gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
+        classpath "com.dicedmelon.gradle:jacoco-android:$jacoco_android_plugin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/config/jacoco.gradle
+++ b/config/jacoco.gradle
@@ -1,13 +1,22 @@
 apply plugin: 'jacoco'
 
-jacoco {
-    toolVersion = jacoco_core_version
-    reportsDir = file("$buildDir/reports/jacoco")
-}
+def fileGenerated = ['**/R.class',
+                     '**/R$*.class',
+                     '**/*$ViewBinder*.*',
+                     '**/*$InjectAdapter*.*',
+                     '**/*Injector*.*',
+                     '**/BuildConfig.*',
+                     '**/Manifest*.*',
+                     '**/*_ViewBinding*.*',
+                     '**/*Adapter*.*',
+                     '**/*Test*.*',
+                     'android/**/*.*']
 
-tasks.withType(Test) {
-    jacoco.includeNoLocationClasses = true
-}
+def packagesExcluded = ['com/nimbl3/di/**',
+                        'com/nimbl3/ui/**/di/**',
+                        'com/bumptech/glide']
+
+def fileFilter = fileGenerated + packagesExcluded
 
 task jacocoTestReport(type: JacocoReport) {
     group = "Reporting"
@@ -16,30 +25,11 @@ task jacocoTestReport(type: JacocoReport) {
     dependsOn ":app:testStagingDebugUnitTest"
     dependsOn ":data:testStagingDebugUnitTest"
 
-    def fileGenerated = ['**/R.class',
-                         '**/R$*.class',
-                         '**/*$ViewBinder*.*',
-                         '**/*$InjectAdapter*.*',
-                         '**/*Injector*.*',
-                         '**/BuildConfig.*',
-                         '**/Manifest*.*',
-                         '**/*_ViewBinding*.*',
-                         '**/*Adapter*.*',
-                         '**/*Test*.*',
-                         'android/**/*.*']
-
-    def packagesExcluded = ['com/nimbl3/di/**',
-                            'com/nimbl3/ui/**/di/**',
-                            'com/nimbl3/extension/**',
-                            'com/nimbl3/**/extension/**']
-
-    def fileFilter = fileGenerated + packagesExcluded
-
     classDirectories.from = fileTree(
-        dir: "$buildDir/intermediates/javac/stagingDebug/classes",
+        dir: "$project.rootDir/app/build/intermediates/javac/stagingDebug/classes",
         excludes: fileFilter
     ) + fileTree(
-        dir: "$buildDir/intermediates/javac/stagingDebug/classes",
+        dir: "$project.rootDir/data/build/intermediates/javac/stagingDebug/classes",
         excludes: fileFilter
     ) + fileTree(
         dir: "$project.rootDir/app/build/tmp/kotlin-classes/stagingDebug",
@@ -51,16 +41,14 @@ task jacocoTestReport(type: JacocoReport) {
 
     sourceDirectories.from = files([
         "$project.rootDir/app/src/main/java",
-        "$project.rootDir/data/src/main/java"])
+        "$project.rootDir/data/src/main/java"
+    ])
 
     executionData.from = fileTree(dir: project.rootDir, includes: [
-        'app/build/jacoco/testStagingDebugUnitTest.exec',
-        'data/build/jacoco/testStagingDebugUnitTest.exec'])
+        "app/build/jacoco/testStagingDebugUnitTest.exec",
+        "data/build/jacoco/testStagingDebugUnitTest.exec"
+    ])
 
-    reports {
-        xml.enabled = true
-        html.enabled = true
-    }
 }
 
 tasks.withType(Test) {

--- a/config/jacoco.gradle
+++ b/config/jacoco.gradle
@@ -1,13 +1,20 @@
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.3"
+    toolVersion = "$jacoco_core_version"
     reportsDir = file("$buildDir/reports/jacoco")
 }
 
-task jacocoTestReport(type: JacocoReport, dependsOn: "testStagingDebugUnitTest") {
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
+
+task jacocoTestReport(type: JacocoReport) {
     group = "Reporting"
     description = "Generate Jacoco coverage reports for Debug build"
+
+    dependsOn ":app:testStagingDebugUnitTest"
+    dependsOn ":data:testStagingDebugUnitTest"
 
     def fileGenerated = ['**/R.class',
                          '**/R$*.class',
@@ -22,27 +29,39 @@ task jacocoTestReport(type: JacocoReport, dependsOn: "testStagingDebugUnitTest")
                          'android/**/*.*']
 
     def packagesExcluded = ['com/nimbl3/di/**',
+                            'com/nimbl3/ui/**/di/**',
                             'com/nimbl3/extension/**',
                             'com/nimbl3/**/extension/**']
     // def filesExcluded = [ ]
     // def fileFilter = fileGenerated + packagesExcluded + filesExcluded
     def fileFilter = fileGenerated + packagesExcluded
 
-    classDirectories = fileTree(
-        dir: "$buildDir/intermediates/javac/stagingDebug/compileStagingDebugJavaWithJavac/classes",
+    classDirectories.from = fileTree(
+        dir: "$project.rootDir/app/build/intermediates/javac/stagingDebug/compileStagingDebugJavaWithJavac/classes",
         excludes: fileFilter
     ) + fileTree(
-        dir: "$buildDir/tmp/kotlin-classes/stagingDebug",
+        dir: "$project.rootDir/data/build/intermediates/javac/stagingDebug/compileStagingDebugJavaWithJavac/classes",
+        excludes: fileFilter
+    ) + fileTree(
+        dir: "$project.rootDir/app/build/tmp/kotlin-classes/stagingDebug",
+        excludes: fileFilter
+    ) + fileTree(
+        dir: "$project.rootDir/data/build/tmp/kotlin-classes/stagingDebug",
         excludes: fileFilter
     )
+
+    sourceDirectories.from = files([
+        "$project.rootDir/app/src/main/java",
+        "$project.rootDir/data/src/main/java"])
+
+    executionData.from = fileTree(dir: project.rootDir, includes: [
+        'app/build/jacoco/testStagingDebugUnitTest.exec',
+        'data/build/jacoco/testStagingDebugUnitTest.exec'])
+
     reports {
         xml.enabled = true
         html.enabled = true
     }
-    sourceDirectories = files([
-        android.sourceSets.main.java.srcDirs
-    ])
-    executionData = files("$buildDir/jacoco/testStagingDebugUnitTest.exec")
 }
 
 tasks.withType(Test) {

--- a/config/jacoco.gradle
+++ b/config/jacoco.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "$jacoco_core_version"
+    toolVersion = jacoco_core_version
     reportsDir = file("$buildDir/reports/jacoco")
 }
 
@@ -32,15 +32,14 @@ task jacocoTestReport(type: JacocoReport) {
                             'com/nimbl3/ui/**/di/**',
                             'com/nimbl3/extension/**',
                             'com/nimbl3/**/extension/**']
-    // def filesExcluded = [ ]
-    // def fileFilter = fileGenerated + packagesExcluded + filesExcluded
+
     def fileFilter = fileGenerated + packagesExcluded
 
     classDirectories.from = fileTree(
-        dir: "$project.rootDir/app/build/intermediates/javac/stagingDebug/compileStagingDebugJavaWithJavac/classes",
+        dir: "$buildDir/intermediates/javac/stagingDebug/classes",
         excludes: fileFilter
     ) + fileTree(
-        dir: "$project.rootDir/data/build/intermediates/javac/stagingDebug/compileStagingDebugJavaWithJavac/classes",
+        dir: "$buildDir/intermediates/javac/stagingDebug/classes",
         excludes: fileFilter
     ) + fileTree(
         dir: "$project.rootDir/app/build/tmp/kotlin-classes/stagingDebug",

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'kotlin-android-extensions'
 apply from: '../config/jacoco.gradle'
 
 def globalConfig = rootProject.extensions.getByName("ext")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Mon Mar 12 14:38:32 ICT 2018
+#Wed Mar 25 10:51:50 ICT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 org.gradle.parallel=true


### PR DESCRIPTION
## What happened 🤔
The report has shown only one module when we open index.html in browser from both modules.
This is a step for checking.
- run ./gradlew jacocoTestReport testStagingDebugUnitTest
- open index.html in browser from the data module, You will see the report only one module that is "com.nimble3.data..."
- open index.html in browser from app module, The report has shown the same with data module that is "com.nimble3.data..." but it should be show "com.nimble3.ui..." or both modules.
 
![Screen Shot 2563-03-27 at 10 13 36](https://user-images.githubusercontent.com/28002315/77717866-0bed9d80-7014-11ea-8add-0fb74612bf47.png)
<img width="349" alt="Screen Shot 2563-03-27 at 10 13 51" src="https://user-images.githubusercontent.com/28002315/77717880-127c1500-7014-11ea-8528-bc790e7b515d.png">
<img width="349" alt="Screen Shot 2563-03-27 at 10 14 10" src="https://user-images.githubusercontent.com/28002315/77717887-1740c900-7014-11ea-9744-caeec374cec2.png">

## Insight 👀
Update the directory file task jacoco in jacoco.gragle script.
We need to define a directory file for both app and data modules.

## PoW (a.k.a Proof Of Work)💪
Run script -> ./gradlew jacocoTestReport, ./gradlew jacocoTestReport testStagingDebugUnitTest

![Screen Shot 2563-04-08 at 13 01 54](https://user-images.githubusercontent.com/28002315/78750025-9da4c580-7999-11ea-963b-4397f91c798d.png)
![Screen Shot 2563-04-08 at 14 24 18](https://user-images.githubusercontent.com/28002315/78756405-f0d04580-79a4-11ea-9322-bb513e947fc2.png)
![Screen Shot 2563-04-08 at 14 24 27](https://user-images.githubusercontent.com/28002315/78756416-f4fc6300-79a4-11ea-85e8-1914cfffa9be.png)







