### PR TITLE
[Feature] Optimize loading handling by adding `doShowLoading` operator

### DIFF
--- a/app/src/main/java/co/nimblehq/ui/ErrorMapping.kt
+++ b/app/src/main/java/co/nimblehq/ui/ErrorMapping.kt
@@ -1,4 +1,4 @@
-package co.nimblehq.extension
+package co.nimblehq.ui
 
 import android.content.Context
 import co.nimblehq.R
@@ -6,7 +6,7 @@ import co.nimblehq.domain.data.error.AppError
 import co.nimblehq.domain.data.error.ValidateError
 
 fun Throwable.userReadableMessage(context: Context, vararg formatArgs: Any?): String {
-    // FIXME: Check AppError instead. Other specific Error should be added into UseCase
+    // FIXME Check AppError instead. Other specific Error should be added into UseCase
     val customErrorMessage = when (this) {
         is ValidateError.InvalidEmailError -> context.getString(R.string.error_email_invalid)
         is ValidateError.InvalidPasswordError -> context.getString(

--- a/app/src/main/java/co/nimblehq/ui/base/BaseActivity.kt
+++ b/app/src/main/java/co/nimblehq/ui/base/BaseActivity.kt
@@ -4,8 +4,8 @@ import android.os.Bundle
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import co.nimblehq.domain.schedulers.SchedulerProvider
-import co.nimblehq.extension.userReadableMessage
 import co.nimblehq.ui.common.Toaster
+import co.nimblehq.ui.userReadableMessage
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable

--- a/app/src/main/java/co/nimblehq/ui/base/BaseFragment.kt
+++ b/app/src/main/java/co/nimblehq/ui/base/BaseFragment.kt
@@ -9,8 +9,8 @@ import androidx.fragment.app.Fragment
 import co.nimblehq.domain.schedulers.SchedulerProvider
 import co.nimblehq.extension.hideSoftKeyboard
 import co.nimblehq.extension.subscribeOnClick
-import co.nimblehq.extension.userReadableMessage
 import co.nimblehq.ui.common.Toaster
+import co.nimblehq.ui.userReadableMessage
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable

--- a/app/src/main/java/co/nimblehq/ui/base/BaseViewModel.kt
+++ b/app/src/main/java/co/nimblehq/ui/base/BaseViewModel.kt
@@ -37,7 +37,7 @@ abstract class BaseViewModel : ViewModel() {
         get() = _navigator
 
     /**
-     * To show loading manually
+     * To show loading manually, should call `hideLoading` after
      */
     protected fun showLoading() {
         if (loadingCount == 0) {
@@ -47,7 +47,7 @@ abstract class BaseViewModel : ViewModel() {
     }
 
     /**
-     * To hide loading manually
+     * To hide loading manually, should be called after `showLoading`
      */
     protected fun hideLoading() {
         loadingCount--

--- a/app/src/main/java/co/nimblehq/ui/base/BaseViewModel.kt
+++ b/app/src/main/java/co/nimblehq/ui/base/BaseViewModel.kt
@@ -2,21 +2,25 @@ package co.nimblehq.ui.base
 
 import androidx.lifecycle.ViewModel
 import co.nimblehq.lib.IsLoading
+import io.reactivex.Completable
+import io.reactivex.Flowable
 import io.reactivex.Observable
+import io.reactivex.Single
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.addTo
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 
-@Suppress("VariableNaming")
+@Suppress("PropertyName")
 abstract class BaseViewModel : ViewModel() {
 
-    protected val _showLoading = BehaviorSubject.create<IsLoading>()
+    private val _showLoading = BehaviorSubject.createDefault(false)
     protected val _error = BehaviorSubject.create<Throwable>()
     protected val _navigator = PublishSubject.create<NavigationEvent>()
 
     private val disposables by lazy { CompositeDisposable() }
+    private var loadingCount: Int = 0
 
     override fun onCleared() {
         super.onCleared()
@@ -31,6 +35,47 @@ abstract class BaseViewModel : ViewModel() {
 
     val navigator: Observable<NavigationEvent>
         get() = _navigator
+
+    /**
+     * To show loading manually
+     */
+    protected fun showLoading() {
+        if (loadingCount == 0) {
+            _showLoading.onNext(true)
+        }
+        loadingCount++
+    }
+
+    /**
+     * To hide loading manually
+     */
+    protected fun hideLoading() {
+        loadingCount--
+        if (loadingCount == 0) {
+            _showLoading.onNext(false)
+        }
+    }
+
+    /**
+     * To manage show/hide loading automatically for Single operator
+     */
+    protected fun <T> Single<T>.doShowLoading(): Single<T> = this
+        .doOnSubscribe { showLoading() }
+        .doFinally { hideLoading() }
+
+    /**
+     * To manage show/hide loading automatically for Flowable operator
+     */
+    protected fun <T> Flowable<T>.doShowLoading(): Flowable<T> = this
+        .doOnSubscribe { showLoading() }
+        .doFinally { hideLoading() }
+
+    /**
+     * To manage show/hide loading automatically for Completable operator
+     */
+    protected fun Completable.doShowLoading(): Completable = this
+        .doOnSubscribe { showLoading() }
+        .doFinally { hideLoading() }
 
     protected fun Disposable.addToDisposables() = addTo(disposables)
 }

--- a/app/src/main/java/co/nimblehq/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/co/nimblehq/ui/screens/home/HomeViewModel.kt
@@ -27,7 +27,7 @@ class HomeViewModel @ViewModelInject constructor(
         fetchApi()
     }
 
-    val input = this
+    val input: Input = this
 
     val data: Observable<Data>
         get() = _data

--- a/app/src/main/java/co/nimblehq/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/co/nimblehq/ui/screens/home/HomeViewModel.kt
@@ -51,12 +51,9 @@ class HomeViewModel @ViewModelInject constructor(
     private fun fetchApi() {
         getExampleDataUseCase
             .execute(Unit)
-            .doOnSubscribe { _showLoading.onNext(true) }
+            .doShowLoading()
             .subscribeBy(
-                onSuccess = {
-                    _data.onNext(it)
-                    _showLoading.onNext(false)
-                },
+                onSuccess = _data::onNext,
                 onError = _error::onNext
             )
             .addToDisposables()

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -109,7 +109,7 @@ empty-blocks:
   EmptyForBlock:
     active: true
   EmptyFunctionBlock:
-    active: true
+    active: false
   EmptyIfBlock:
     active: true
   EmptyInitBlock:
@@ -213,7 +213,7 @@ naming:
     minimumVariableNameLength: 1
   VariableNaming:
     active: true
-    variablePattern: '[a-z][A-Za-z0-9]*'
+    variablePattern: '(_)?[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
 
 performance:


### PR DESCRIPTION
## What happened 🤔
- Currently, whenever a task is being subscribed, we always try to show and hide the loading by `doOnSubscribe` and `doFinally` (or sometimes `doOnError`). 

For example:
```
getExampleDataUseCase
            .execute(Unit)
            .doOnSubscribe { _showLoading.onNext(true) }
            .toObservable()
```
```
_refresh
            .flatMap { fetchApi() }
            .subscribeBy(
                onNext = {
                    _data.onNext(it)
                    _showLoading.onNext(false)
                },
                onError = _error::onNext
            )
            .addToDisposables()
```

This way will inject multiple items into `_showLoading` and made our tests hard to check and messy.
```
loadingObserver
            .assertNoErrors()
            .assertValues(false, true, true, true, false, false, false)
```
- It also makes us hard to manage to show or hide loading when there are multiple parallel running tasks in VM


## Insight 👀
- Keep a counted object of `_showLoading` state, only show the loading if there is no loading triggered yet and hide loading if there is only 1 loading.

In `BaseViewModel`
```
private var loadingCount: Int = 0

    protected fun showLoading() {
        if (loadingCount == 0) {
            _showLoading.onNext(true)
        }
        loadingCount++
    }

    protected fun hideLoading() {
        loadingCount--
        if (loadingCount == 0) {
            _showLoading.onNext(false)
        }
    }
```

