### PR TITLE
[CHORE] Add Github CODEOWNERS config: auto-request all members for code review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# These users will be requested for review when someone opens a pull request.
+*       @luongvo @sleepylee @hoangnguyen92dn @lydiasama @Tuubz @minhnimble @manh-t @AVI5HEK @Wadeewee @chornerman


### PR DESCRIPTION
## What happened 🤔

Need to automate adding reviewers when opening new PR process to have all @nimblehq/android-chapter members participation. 🤓 


## Insight 👀

Give a kudos to Github for [this CODEOWNERS config support](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) ⭐  


## PoW (a.k.a Proof Of Work)💪

All @nimblehq/android-chapter members now should be added automatically into new open PRs ✅ 