### PR TITLE
[#105] Update Mockito library to fix some unit tests fail issues for RxJavaTemplate

### DIFF
--- a/RxJavaTemplate/app/build.gradle
+++ b/RxJavaTemplate/app/build.gradle
@@ -164,7 +164,7 @@ dependencies {
     testImplementation(
         "junit:junit:$test_junit_version",
         "org.amshove.kluent:kluent-android:$test_kluent_version",
-        "com.nhaarman.mockitokotlin2:mockito-kotlin:$test_mockito_version",
+        "org.mockito.kotlin:mockito-kotlin:$test_mockito_version",
         "org.robolectric:shadowapi:$test_robolectric_version"
     )
 

--- a/RxJavaTemplate/app/src/test/java/co/nimblehq/rxjava/ui/screens/MainNavigatorTest.kt
+++ b/RxJavaTemplate/app/src/test/java/co/nimblehq/rxjava/ui/screens/MainNavigatorTest.kt
@@ -10,10 +10,10 @@ import co.nimblehq.rxjava.ui.screens.home.HomeFragmentDirections
 import co.nimblehq.rxjava.ui.screens.second.SecondBundle
 import co.nimblehq.rxjava.ui.screens.second.SecondFragmentDirections
 import co.nimblehq.rxjava.ui.screens.webview.WebViewBundle
-import com.nhaarman.mockitokotlin2.verify
 import org.amshove.kluent.*
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito.verify
 import org.robolectric.util.ReflectionHelpers
 
 class MainNavigatorTest {

--- a/RxJavaTemplate/app/src/test/java/co/nimblehq/rxjava/ui/screens/home/HomeViewModelTest.kt
+++ b/RxJavaTemplate/app/src/test/java/co/nimblehq/rxjava/ui/screens/home/HomeViewModelTest.kt
@@ -5,7 +5,6 @@ import co.nimblehq.rxjava.domain.test.MockUtil
 import co.nimblehq.rxjava.domain.usecase.GetExampleDataUseCase
 import co.nimblehq.rxjava.ui.base.NavigationEvent
 import co.nimblehq.rxjava.ui.screens.second.SecondBundle
-import com.nhaarman.mockitokotlin2.any
 import io.reactivex.Single
 import org.amshove.kluent.*
 import org.junit.Before

--- a/RxJavaTemplate/build.gradle
+++ b/RxJavaTemplate/build.gradle
@@ -56,7 +56,7 @@ buildscript {
         test_espresso_version = '3.3.0'
         test_junit_version = '4.13.2'
         test_kluent_version = '1.60'
-        test_mockito_version = '2.1.0'
+        test_mockito_version = '3.2.0'
         test_mockito_dexmaker_version = '2.28.1'
         test_robolectric_version = '4.3.1'
     }

--- a/RxJavaTemplate/data/build.gradle
+++ b/RxJavaTemplate/data/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 
     testImplementation(
         "junit:junit:$test_junit_version",
-        "com.nhaarman.mockitokotlin2:mockito-kotlin:$test_mockito_version",
+        "org.mockito.kotlin:mockito-kotlin:$test_mockito_version",
     )
     testImplementation project(path: ':domain')
 }

--- a/RxJavaTemplate/domain/build.gradle
+++ b/RxJavaTemplate/domain/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     testImplementation(
         "junit:junit:$test_junit_version",
         "org.amshove.kluent:kluent-android:$test_kluent_version",
-        "com.nhaarman.mockitokotlin2:mockito-kotlin:$test_mockito_version",
+        "org.mockito.kotlin:mockito-kotlin:$test_mockito_version",
         "org.robolectric:shadowapi:$test_robolectric_version",
     )
 }


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/105

## What happened 👀

As stated from #105 that when trying to run the unit tests, we are having some failed issues due to the current Mockito library in the app - `com.nhaarman.mockitokotlin2:mockito-kotlin`. Need to update to use a latest library and fix all tests failed issues.
 
## Insight 📝

- Resolved #105 by updating to use a new official library: `org.mockito.kotlin:mockito-kotlin`.
- All the code syntax and test logic is persisted and no need to update.
 
## Proof Of Work 📹

All tests are passed, we can run and build the app and tests successfully without any issue:

<img width="1083" alt="Screen Shot 2021-07-01 at 17 35 27" src="https://user-images.githubusercontent.com/70877098/124110995-0393d600-da93-11eb-9690-81eeb19d0909.png">

