### PR TITLE
[98] Add BaseSharedPreferences to CoroutineTemplate

### DIFF
--- a/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/di/modules/StorageModule.kt
+++ b/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/di/modules/StorageModule.kt
@@ -10,7 +10,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/di/modules/StorageModule.kt
+++ b/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/di/modules/StorageModule.kt
@@ -1,0 +1,35 @@
+package co.nimblehq.coroutine.di.modules
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.preference.PreferenceManager
+import co.nimblehq.coroutine.domain.storage.EncryptedSharedPreferences
+import co.nimblehq.coroutine.domain.storage.NormalSharedPreferences
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class StorageModule {
+
+    companion object {
+
+        @Provides
+        fun provideDefaultSharedPreferences(@ApplicationContext context: Context): SharedPreferences =
+            PreferenceManager.getDefaultSharedPreferences(context)
+
+        @Provides
+        fun provideSecuredLocalStorage(@ApplicationContext context: Context) =
+            EncryptedSharedPreferences(context)
+
+        @Provides
+        fun provideNormalLocalStorage(
+            @ApplicationContext context: Context,
+            defaultSharedPreferences: SharedPreferences
+        ) = NormalSharedPreferences(context, defaultSharedPreferences)
+    }
+}

--- a/CoroutineTemplate/build.gradle
+++ b/CoroutineTemplate/build.gradle
@@ -5,12 +5,14 @@ buildscript {
         build_gradle_version = '4.2.1'
 
         android_compile_sdk_version = 30
-        android_min_sdk_version = 21
+        android_min_sdk_version = 23
         android_target_sdk_version = 30
 
         android_version_code = 1
         android_version_name = '0.1.0'
 
+        // Dependencies (Alphabet sorted)
+        android_crypto_version = '1.0.0'
         androidx_activity_ktx_version = '1.2.1'
         androidx_core_ktx_version = '1.3.0'
         androidx_lifecycle_version = '2.4.0-alpha02'

--- a/CoroutineTemplate/domain/build.gradle
+++ b/CoroutineTemplate/domain/build.gradle
@@ -34,6 +34,7 @@ dependencies {
         project(':data'),
 
         "androidx.core:core-ktx:$androidx_core_ktx_version",
+        "androidx.security:security-crypto:$android_crypto_version",
         "com.google.dagger:hilt-android:$hilt_version",
         "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinx_coroutines_version"
     )

--- a/CoroutineTemplate/domain/src/main/java/co/nimblehq/coroutine/domain/extension/SharedPreferencesExt.kt
+++ b/CoroutineTemplate/domain/src/main/java/co/nimblehq/coroutine/domain/extension/SharedPreferencesExt.kt
@@ -1,0 +1,10 @@
+package co.nimblehq.coroutine.domain.extension
+
+import android.content.SharedPreferences
+
+fun SharedPreferences.execute(operation: (SharedPreferences.Editor) -> Unit) {
+    with(edit()) {
+        operation(this)
+        apply()
+    }
+}

--- a/CoroutineTemplate/domain/src/main/java/co/nimblehq/coroutine/domain/storage/BaseSharedPreferences.kt
+++ b/CoroutineTemplate/domain/src/main/java/co/nimblehq/coroutine/domain/storage/BaseSharedPreferences.kt
@@ -1,0 +1,40 @@
+package co.nimblehq.coroutine.domain.storage
+
+import android.content.SharedPreferences
+import co.nimblehq.coroutine.domain.extension.execute
+
+abstract class BaseSharedPreferences {
+
+    protected lateinit var sharedPreferences: SharedPreferences
+
+    protected fun <T> set(key: String, value: T?) {
+        sharedPreferences.execute {
+            when (value) {
+                null -> it.remove(key)
+                is Boolean -> it.putBoolean(key, value)
+                is String -> it.putString(key, value)
+                is Float -> it.putFloat(key, value)
+                is Long -> it.putLong(key, value)
+                is Int -> it.putInt(key, value)
+            }
+        }
+    }
+
+    protected inline fun <reified T> get(key: String): T? =
+        if (sharedPreferences.contains(key)) {
+            when (T::class) {
+                Boolean::class -> sharedPreferences.getBoolean(key, false) as T?
+                String::class -> sharedPreferences.getString(key, null) as T?
+                Float::class -> sharedPreferences.getFloat(key, 0f) as T?
+                Int::class -> sharedPreferences.getInt(key, 0) as T?
+                Long::class -> sharedPreferences.getLong(key, 0L) as T?
+                else -> null
+            }
+        } else {
+            null
+        }
+
+    protected fun clearAll() {
+        sharedPreferences.execute { it.clear() }
+    }
+}

--- a/CoroutineTemplate/domain/src/main/java/co/nimblehq/coroutine/domain/storage/BaseSharedPreferences.kt
+++ b/CoroutineTemplate/domain/src/main/java/co/nimblehq/coroutine/domain/storage/BaseSharedPreferences.kt
@@ -7,19 +7,6 @@ abstract class BaseSharedPreferences {
 
     protected lateinit var sharedPreferences: SharedPreferences
 
-    protected fun <T> set(key: String, value: T?) {
-        sharedPreferences.execute {
-            when (value) {
-                null -> it.remove(key)
-                is Boolean -> it.putBoolean(key, value)
-                is String -> it.putString(key, value)
-                is Float -> it.putFloat(key, value)
-                is Long -> it.putLong(key, value)
-                is Int -> it.putInt(key, value)
-            }
-        }
-    }
-
     protected inline fun <reified T> get(key: String): T? =
         if (sharedPreferences.contains(key)) {
             when (T::class) {
@@ -33,6 +20,22 @@ abstract class BaseSharedPreferences {
         } else {
             null
         }
+
+    protected fun <T> set(key: String, value: T) {
+        sharedPreferences.execute {
+            when (value) {
+                is Boolean -> it.putBoolean(key, value)
+                is String -> it.putString(key, value)
+                is Float -> it.putFloat(key, value)
+                is Long -> it.putLong(key, value)
+                is Int -> it.putInt(key, value)
+            }
+        }
+    }
+
+    protected fun remove(key: String) {
+        sharedPreferences.execute { it.remove(key) }
+    }
 
     protected fun clearAll() {
         sharedPreferences.execute { it.clear() }

--- a/CoroutineTemplate/domain/src/main/java/co/nimblehq/coroutine/domain/storage/EncryptedSharedPreferences.kt
+++ b/CoroutineTemplate/domain/src/main/java/co/nimblehq/coroutine/domain/storage/EncryptedSharedPreferences.kt
@@ -1,0 +1,23 @@
+package co.nimblehq.coroutine.domain.storage
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import javax.inject.Inject
+
+private const val APP_SECRET_SHARED_PREFS = "app_secret_shared_prefs"
+
+class EncryptedSharedPreferences @Inject constructor(applicationContext: Context) :
+    BaseSharedPreferences() {
+
+    init {
+        val masterKey = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+        sharedPreferences = EncryptedSharedPreferences.create(
+            APP_SECRET_SHARED_PREFS,
+            masterKey,
+            applicationContext,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+}

--- a/CoroutineTemplate/domain/src/main/java/co/nimblehq/coroutine/domain/storage/NormalSharedPreferences.kt
+++ b/CoroutineTemplate/domain/src/main/java/co/nimblehq/coroutine/domain/storage/NormalSharedPreferences.kt
@@ -1,0 +1,24 @@
+package co.nimblehq.coroutine.domain.storage
+
+import android.content.Context
+import android.content.SharedPreferences
+import javax.inject.Inject
+
+class NormalSharedPreferences @Inject constructor(
+    private val applicationContext: Context,
+    private val defaultSharedPreferences: SharedPreferences
+) : BaseSharedPreferences() {
+
+    init {
+        useDefaultSharedPreferences()
+    }
+
+    fun useDefaultSharedPreferences() {
+        sharedPreferences = defaultSharedPreferences
+    }
+
+    // Use this function for creating a custom sharedPreferences if needed
+    fun useCustomSharedPreferences(name: String) {
+        sharedPreferences = applicationContext.getSharedPreferences(name, Context.MODE_PRIVATE)
+    }
+}

--- a/RxJavaTemplate/domain/src/main/java/co/nimblehq/rxjava/domain/storage/BaseSharedPreferences.kt
+++ b/RxJavaTemplate/domain/src/main/java/co/nimblehq/rxjava/domain/storage/BaseSharedPreferences.kt
@@ -7,19 +7,6 @@ abstract class BaseSharedPreferences {
 
     protected lateinit var sharedPreferences: SharedPreferences
 
-    protected fun <T> set(key: String, value: T?) {
-        sharedPreferences.execute {
-            when (value) {
-                null -> it.remove(key)
-                is Boolean -> it.putBoolean(key, value)
-                is String -> it.putString(key, value)
-                is Float -> it.putFloat(key, value)
-                is Long -> it.putLong(key, value)
-                is Int -> it.putInt(key, value)
-            }
-        }
-    }
-
     protected inline fun <reified T> get(key: String): T? =
         if (sharedPreferences.contains(key)) {
             when (T::class) {
@@ -33,6 +20,22 @@ abstract class BaseSharedPreferences {
         } else {
             null
         }
+
+    protected fun <T> set(key: String, value: T) {
+        sharedPreferences.execute {
+            when (value) {
+                is Boolean -> it.putBoolean(key, value)
+                is String -> it.putString(key, value)
+                is Float -> it.putFloat(key, value)
+                is Long -> it.putLong(key, value)
+                is Int -> it.putInt(key, value)
+            }
+        }
+    }
+
+    protected fun remove(key: String) {
+        sharedPreferences.execute { it.remove(key) }
+    }
 
     protected fun clearAll() {
         sharedPreferences.execute { it.clear() }


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/98

## What happened 👀

We are using SharedPreferences on most current projects for caching data. Creating BaseSharedPreferences for common usage.
 
## Insight 📝

- Bring `SharedPreferences` implementation from RxJavaTemplate to this CoroutineTemplate as per [comment](https://github.com/nimblehq/android-templates/pull/101#issuecomment-871204647) from @hoangnguyen92dn.
- Adjust some DI implementations to match with this template's DI library version.
 
## Proof Of Work 📹

- Just under the hood optimization, no visual changes. The app is built and running successfully:

<img width="1431" alt="Screen Shot 2021-07-02 at 13 54 53" src="https://user-images.githubusercontent.com/70877098/124233527-2084e380-db3d-11eb-8725-140449241f60.png">

