### PR TITLE
Add the Github release PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,17 @@
+Note: for a release PR, append this parameter `?template=release_template.md` to the current URL to apply the release PR template, e.g. `{Github PR URL}?template=release_template.md`
+
+--
+
 https://github.com/nimblehq/android-templates/issues/??
 
 ## What happened 👀
 
-Describe the big picture of your changes here to communicate to the team why we should accept this pull request. 
- 
+Describe the big picture of your changes here to communicate to the team why we should accept this pull request.
+
 ## Insight 📝
 
 Describe in details how to test the changes, which solution you tried but did not go with, referenced documentation is welcome as well.
- 
+
 ## Proof Of Work 📹
 
 Show us the implementation: screenshots, gif, etc.

--- a/.github/PULL_REQUEST_TEMPLATE/RELEASE_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/RELEASE_TEMPLATE.md
@@ -1,0 +1,17 @@
+Link to the milestone on Github e.g. https://github.com/nimblehq/git-templates/milestone/41?closed=1
+or
+Link to the project management tool for the release
+
+## Features
+
+Provide the ID and title of the issue in the section for each type (feature, chore and bug). The link is optional.
+
+- [ch1234] As a user, I can log in
+  or
+- [[ch1234](https://github.com/nimblehq/git-templates/issues/1234)] As a user, I can log in
+
+## Chores
+- Same structure as in  ## Feature
+
+## Bugs
+- Same structure as in  ## Feature


### PR DESCRIPTION
Resolves #112 

## What happened 👀

As part of the engineering initiatives, this PR adds the Github template for the release pull requests that match Nimble's [convention](https://nimblehq.co/compass/development/version-control/release-management/#release-pull-request).
 
## Insight 📝

The implementation is identical with https://github.com/nimblehq/git-template/pull/15. 
Github supports multiple [templates for issues and pull requests](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates). For example, to define multiple pull request templates, simply define them like this:
```bash
.github
└── PULL_REQUEST_TEMPLATE
    ├── normal_template.md
    └── release_template.md
```

But unlike issue templates - when opening a new issue, Github will show a template selection menu:
<img width="1182" alt="Screen Shot 2021-06-24 at 09 24 41" src="https://user-images.githubusercontent.com/1896814/123192905-02c8d600-d4ce-11eb-8768-2dfd3232bcf3.png">

even with multiple pull request templates defined, a UI to select the template isn't available yet. It is a known issue (read more: [(1)](https://github.community/t/multiple-pull-request-templates/1850), [(2)](https://github.community/t/multiple-pull-request-template/874)). 
As a result, when opening a new pull request, we have to specify the template manually by putting a query param `?template=<template_name.md>` into the pull request URL, e.g. 

`https://github.com/nimblehq/git-template/compare/chore/add-release-pull-request-template?expand=1&`**template=release_template.md**

Also, Github doesn't support setting a default template for new pull requests if putting all templates under `PULL_REQUEST_TEMPLATE` directory

So I ended up organizing the templates like this:
```bash
.github
├── PULL_REQUEST_TEMPLATE
│   └── RELEASE_TEMPLATE.md
└── PULL_REQUEST_TEMPLATE.md
```
with the above structure, when opening a new pull request, without the `?template` param provided, Github still uses the default template defined by `PULL_REQUEST_TEMPLATE.md`. And when we need to use a new template, in this case, the release template, we must specify it in the URL.

 
## Proof Of Work 📹

I created a test repo. When opening a [new pull request](https://github.com/longnd/awesomedemo/compare/main...chore/template) without the `template` param specified, the default template is used:

<img width="930" alt="Screen Shot 2021-06-24 at 09 36 13" src="https://user-images.githubusercontent.com/1896814/123193820-a23a9880-d4cf-11eb-8287-1113b4246b16.png">

And when specify the template, that template is used:

<img width="968" alt="Screen Shot 2021-06-24 at 09 38 53" src="https://user-images.githubusercontent.com/1896814/123194033-ff364e80-d4cf-11eb-998a-7c765665fc8e.png">
