### PR TITLE
[#115] Add Skeleton loading support

### DIFF
--- a/RxJavaTemplate/app/build.gradle
+++ b/RxJavaTemplate/app/build.gradle
@@ -151,7 +151,8 @@ dependencies {
 
         "com.jakewharton.timber:timber:$timber_log_version",
         "com.github.bumptech.glide:glide:$glide_version",
-        "com.github.tbruyelle:rxpermissions:$rxpermission_version"
+        "com.github.tbruyelle:rxpermissions:$rxpermission_version",
+        "com.faltenreich:skeletonlayout:$skeleton_layout_version"
     )
 
     debugImplementation(

--- a/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/extension/ImageViewExtension.kt
+++ b/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/extension/ImageViewExtension.kt
@@ -1,21 +1,49 @@
 package co.nimblehq.rxjava.extension
 
 import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.core.content.ContextCompat
 import co.nimblehq.rxjava.R
-import com.bumptech.glide.load.engine.DiskCacheStrategy
 import co.nimblehq.rxjava.di.modules.GlideApp
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.Target
 
 /**
  * Provide extension functions relates to ImageView and loading image mechanism.
  */
-
-fun ImageView.loadImage(url: String) {
+fun ImageView.loadImage(
+    url: String,
+    onSuccess: (() -> Unit)? = null,
+    onError: (() -> Unit)? = null
+) {
     GlideApp.with(context)
-            .load(url)
-            .placeholder(ColorDrawable(ContextCompat.getColor(context, R.color.black_20a)))
-            .diskCacheStrategy(DiskCacheStrategy.ALL)
-            .fitCenter()
-            .into(this)
+        .load(url)
+        .placeholder(ColorDrawable(ContextCompat.getColor(context, R.color.black_20a)))
+        .diskCacheStrategy(DiskCacheStrategy.ALL)
+        .fitCenter()
+        .listener(object : RequestListener<Drawable> {
+            override fun onResourceReady(
+                resource: Drawable?,
+                model: Any?,
+                target: Target<Drawable>?,
+                dataSource: DataSource?,
+                isFirstResource: Boolean
+            ): Boolean {
+                onSuccess?.invoke()
+                return false
+            }
+
+            override fun onLoadFailed(
+                e: GlideException?, model: Any?,
+                target: Target<Drawable>?, isFirstResource: Boolean
+            ): Boolean {
+                onError?.invoke()
+                return false
+            }
+        })
+        .into(this)
 }

--- a/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/base/BaseFragment.kt
+++ b/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/base/BaseFragment.kt
@@ -141,11 +141,9 @@ abstract class BaseFragment<VB : ViewBinding> : Fragment(), BaseFragmentCallback
         )
     }
 
-    protected fun showOrHideSkeletonLoading(view: View, isLoading: Boolean) {
-        if (isLoading) {
-            skeletons[view.id]?.showSkeleton()
-        } else {
-            skeletons[view.id]?.showOriginal()
+    protected fun View.showOrHideSkeletonLoading(isLoading: Boolean) {
+        skeletons[id]?.run {
+            if (isLoading) showSkeleton() else showOriginal()
         }
     }
 

--- a/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/base/BaseFragment.kt
+++ b/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/base/BaseFragment.kt
@@ -9,7 +9,6 @@ import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
-import co.nimblehq.rxjava.R
 import co.nimblehq.rxjava.domain.schedulers.SchedulerProvider
 import co.nimblehq.rxjava.extension.hideSoftKeyboard
 import co.nimblehq.rxjava.extension.subscribeOnClick
@@ -21,8 +20,6 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.addTo
 import javax.inject.Inject
-
-private const val SKELETON_ITEM_COUNT_DEFAULT = 2
 
 @SuppressWarnings("TooManyFunctions")
 abstract class BaseFragment<VB : ViewBinding> : Fragment(), BaseFragmentCallbacks {
@@ -94,11 +91,7 @@ abstract class BaseFragment<VB : ViewBinding> : Fragment(), BaseFragmentCallback
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        skeletonConfig = SkeletonConfig.default(requireContext()).apply {
-            maskCornerRadius =
-                resources.getDimensionPixelSize(R.dimen.skeleton_mask_corner_radius_circle)
-                    .toFloat()
-        }
+        skeletonConfig = SkeletonConfig.default(requireContext())
 
         (this as? BaseFragmentCallbacks)?.let {
             setWindowStyle()
@@ -144,7 +137,6 @@ abstract class BaseFragment<VB : ViewBinding> : Fragment(), BaseFragmentCallback
     protected fun RecyclerView.applySkeleton(@LayoutRes listItemLayoutResId: Int) {
         skeletons[id] = applySkeleton(
             listItemLayoutResId = listItemLayoutResId,
-            itemCount = SKELETON_ITEM_COUNT_DEFAULT,
             config = skeletonConfig
         )
     }

--- a/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/screens/home/DataAdapter.kt
+++ b/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/screens/home/DataAdapter.kt
@@ -39,7 +39,7 @@ internal class DataAdapter :
 
         init {
             itemView.setOnClickListener {
-                notifyItemClick(OnItemClick.Item(items[adapterPosition]))
+                notifyItemClick(OnItemClick.Item(items[bindingAdapterPosition]))
             }
         }
 

--- a/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/screens/home/HomeFragment.kt
+++ b/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/screens/home/HomeFragment.kt
@@ -6,12 +6,11 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import co.nimblehq.rxjava.R
 import co.nimblehq.rxjava.databinding.FragmentHomeBinding
-import co.nimblehq.rxjava.databinding.ViewLoadingBinding
 import co.nimblehq.rxjava.domain.data.Data
 import co.nimblehq.rxjava.extension.subscribeOnClick
 import co.nimblehq.rxjava.extension.subscribeOnItemClick
-import co.nimblehq.rxjava.extension.visibleOrGone
 import co.nimblehq.rxjava.lib.IsLoading
 import co.nimblehq.rxjava.ui.base.BaseFragment
 import co.nimblehq.rxjava.ui.helpers.handleVisualOverlaps
@@ -28,7 +27,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     private val viewModel by viewModels<HomeViewModel>()
 
     private lateinit var dataAdapter: DataAdapter
-    private lateinit var viewLoadingBinding: ViewLoadingBinding
 
     override val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> FragmentHomeBinding
         get() = { inflater, container, attachToParent ->
@@ -36,7 +34,6 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
         }
 
     override fun setupView() {
-        viewLoadingBinding = ViewLoadingBinding.bind(binding.root)
         setupDataList()
 
         binding.btHomeRefresh
@@ -83,6 +80,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
                     RecyclerView.VERTICAL
                 )
             )
+            applySkeleton(R.layout.item_data)
         }
     }
 
@@ -91,7 +89,9 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     }
 
     private fun showLoading(isLoading: IsLoading) {
-        binding.btHomeRefresh.isEnabled = !isLoading
-        viewLoadingBinding.pbLoading.visibleOrGone(isLoading)
+        with(binding) {
+            btHomeRefresh.isEnabled = !isLoading
+            showOrHideSkeletonLoading(rvHomeData, isLoading)
+        }
     }
 }

--- a/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/screens/home/HomeFragment.kt
+++ b/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/screens/home/HomeFragment.kt
@@ -3,9 +3,7 @@ package co.nimblehq.rxjava.ui.screens.home
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
-import androidx.recyclerview.widget.DividerItemDecoration
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.*
 import co.nimblehq.rxjava.R
 import co.nimblehq.rxjava.databinding.FragmentHomeBinding
 import co.nimblehq.rxjava.domain.data.Data
@@ -91,7 +89,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     private fun showLoading(isLoading: IsLoading) {
         with(binding) {
             btHomeRefresh.isEnabled = !isLoading
-            showOrHideSkeletonLoading(rvHomeData, isLoading)
+            rvHomeData.showOrHideSkeletonLoading(isLoading)
         }
     }
 }

--- a/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/screens/second/SecondFragment.kt
+++ b/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/screens/second/SecondFragment.kt
@@ -47,7 +47,7 @@ class SecondFragment : BaseFragment<FragmentSecondBinding>() {
                 .addToDisposables()
 
             slSecondThumbnail.applySkeleton()
-            showOrHideSkeletonLoading(slSecondThumbnail, isLoading = true)
+            slSecondThumbnail.showOrHideSkeletonLoading(true)
         }
     }
 
@@ -96,10 +96,10 @@ class SecondFragment : BaseFragment<FragmentSecondBinding>() {
                 ivSecondThumbnail.loadImage(
                     thumbnail,
                     onSuccess = {
-                        showOrHideSkeletonLoading(slSecondThumbnail, isLoading = false)
+                        slSecondThumbnail.showOrHideSkeletonLoading(false)
                     },
                     onError = {
-                        showOrHideSkeletonLoading(slSecondThumbnail, isLoading = false)
+                        slSecondThumbnail.showOrHideSkeletonLoading(false)
                     }
                 )
             }

--- a/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/screens/second/SecondFragment.kt
+++ b/RxJavaTemplate/app/src/main/java/co/nimblehq/rxjava/ui/screens/second/SecondFragment.kt
@@ -45,6 +45,9 @@ class SecondFragment : BaseFragment<FragmentSecondBinding>() {
             btOpenPost
                 .subscribeOnClick(viewModel::openPost)
                 .addToDisposables()
+
+            slSecondThumbnail.applySkeleton()
+            showOrHideSkeletonLoading(slSecondThumbnail, isLoading = true)
         }
     }
 
@@ -90,7 +93,15 @@ class SecondFragment : BaseFragment<FragmentSecondBinding>() {
             with(binding) {
                 tvSecondTitle.text = title
                 tvSecondAuthor.text = author
-                ivSecondThumbnail.loadImage(thumbnail)
+                ivSecondThumbnail.loadImage(
+                    thumbnail,
+                    onSuccess = {
+                        showOrHideSkeletonLoading(slSecondThumbnail, isLoading = false)
+                    },
+                    onError = {
+                        showOrHideSkeletonLoading(slSecondThumbnail, isLoading = false)
+                    }
+                )
             }
         }
     }

--- a/RxJavaTemplate/app/src/main/res/layout/fragment_home.xml
+++ b/RxJavaTemplate/app/src/main/res/layout/fragment_home.xml
@@ -24,6 +24,4 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <include layout="@layout/view_loading" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/RxJavaTemplate/app/src/main/res/layout/fragment_second.xml
+++ b/RxJavaTemplate/app/src/main/res/layout/fragment_second.xml
@@ -5,17 +5,24 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/ivSecondThumbnail"
+    <com.faltenreich.skeletonlayout.SkeletonLayout
+        android:id="@+id/slSecondThumbnail"
         android:layout_width="200dp"
         android:layout_height="0dp"
         android:layout_marginTop="50dp"
-        android:scaleType="centerCrop"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:src="@mipmap/ic_launcher" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/ivSecondThumbnail"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop"
+            tools:src="@mipmap/ic_launcher" />
+
+    </com.faltenreich.skeletonlayout.SkeletonLayout>
 
     <TextView
         style="Widget.Template.TextView.Bold"
@@ -27,7 +34,7 @@
         android:textSize="18sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/ivSecondThumbnail"
+        app:layout_constraintTop_toBottomOf="@id/slSecondThumbnail"
         tools:text="title" />
 
     <TextView

--- a/RxJavaTemplate/app/src/main/res/layout/item_data.xml
+++ b/RxJavaTemplate/app/src/main/res/layout/item_data.xml
@@ -10,6 +10,7 @@
         android:id="@+id/ivDataThumbnail"
         android:layout_width="100dp"
         android:layout_height="0dp"
+        android:layout_margin="10dp"
         android:scaleType="centerCrop"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHeight_min="100dp"

--- a/RxJavaTemplate/app/src/main/res/values/dimens.xml
+++ b/RxJavaTemplate/app/src/main/res/values/dimens.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <dimen name="skeleton_mask_corner_radius_circle">1000dp</dimen>
-</resources>

--- a/RxJavaTemplate/app/src/main/res/values/dimens.xml
+++ b/RxJavaTemplate/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="skeleton_mask_corner_radius_circle">1000dp</dimen>
+</resources>

--- a/RxJavaTemplate/build.gradle
+++ b/RxJavaTemplate/build.gradle
@@ -49,6 +49,8 @@ buildscript {
         rxkotlin_version = '2.2.0'
         rxpermission_version = '0.10.2'
 
+        skeleton_layout_version = '4.0.0'
+
         timber_log_version = '4.7.1'
 
         // testing libraries


### PR DESCRIPTION
Solves #115

## What happened 👀

We can add `Skeleton` loading - which brings better UX - as an option to show the loading progress on listview or a single view beside the `ProgressBar`.
 
## Insight 📝

There are 2 good candidates with 2 different ways to implement:
- [Facebook shimmer-android](https://github.com/facebook/shimmer-android) basically produces a shimmer effect on the layout, so what we need is to create skeleton layouts to fake the main layout components.
- [SkeletonLayout](https://github.com/Faltenreich/SkeletonLayout) produces an automatic way to create a skeleton, what we need is executing `createSkeleton` or `applySkeleton` on `RecyclerView` or `ViewPager2`.

To ease and simplify the implementation process, I decided to give it a try with the second candidate.
 
## Proof Of Work 📹


https://user-images.githubusercontent.com/16315358/129722568-372df742-34a4-44b7-aa43-6df45ff6c251.mp4



- Home screen

<img src="https://user-images.githubusercontent.com/16315358/129722643-5fa14bb5-1a11-461b-a69a-2eb2b29e0c9a.png" width=320 />

- Second (with a fake delay to see the loading on the image)

<img src="https://user-images.githubusercontent.com/16315358/129722653-02fc796a-f51e-426d-97cd-9eae76251422.png" width=320 />