### PR TITLE
[#119] Add action to publish docs to Wiki

### DIFF
--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -8,18 +8,19 @@ on:
       - main
       
 env:
-  USER_TOKEN: ${{ secrets.USER_TOKEN }}
+  USER_TOKEN: ${{ secrets.WIKI_ACTION_TOKEN }}
   USER_NAME: team-nimblehq
   USER_EMAIL: dev@nimblehq.co
   OWNER: ${{ github.event.repository.owner.name }}
   REPOSITORY_NAME: ${{ github.event.repository.name }}
 
 jobs:
-  Publish-Docs-To-Wiki:
+  publish_docs_to_wiki:
     runs-on: ubuntu-latest
     steps:  
     - uses: actions/checkout@v2
-    - name: Prepare
+
+    - name: Pull wiki
       run: |
          mkdir tmp_wiki
          cd tmp_wiki
@@ -27,7 +28,8 @@ jobs:
          git config user.name $USER_NAME
          git config user.email $USER_EMAIL
          git pull https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git
-    - name: Push
+
+    - name: Push wiki
       run: |
         rsync -av --delete docs/ tmp_wiki/ --exclude .git
         cd tmp_wiki

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -1,0 +1,36 @@
+name: Publish docs to Wiki
+
+on:
+  push:
+    paths:
+      - docs/**
+    branches:
+      - main
+      
+env:
+  USER_TOKEN: ${{ secrets.USER_TOKEN }}
+  USER_NAME: team-nimblehq
+  USER_EMAIL: dev@nimblehq.co
+  OWNER: ${{ github.event.repository.owner.name }}
+  REPOSITORY_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  Publish-Docs-To-Wiki:
+    runs-on: ubuntu-latest
+    steps:  
+    - uses: actions/checkout@v2
+    - name: Prepare
+      run: |
+         mkdir tmp_wiki
+         cd tmp_wiki
+         git init
+         git config user.name $USER_NAME
+         git config user.email $USER_EMAIL
+         git pull https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git
+    - name: Push
+      run: |
+        rsync -av --delete docs/ tmp_wiki/ --exclude .git
+        cd tmp_wiki
+        git add .
+        git commit -m "Update Wiki content"
+        git push -f --set-upstream https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git master

--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ Example:
 ![Nimble](https://assets.nimblehq.co/logo/dark/logo-dark-text-160.png)
 
 This project is maintained and funded by Nimble.
+
+Learn more about our Android templates on the [Wiki](https://github.com/nimblehq/android-templates/wiki).

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,3 @@
+Welcome to the android-templates wiki! 
+
+More coming soon...


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/119

## What happened 👀

- Add link to Wiki in READM.me
- Add first doc (`Home.md`)
- Add GitHub action for publishing docs to Wiki

The idea was taken from [wiki-page-creator-action](https://github.com/Decathlon/wiki-page-creator-action), however this has its limitations:

- No support for removing Wiki pages with pull requests: [issue](https://github.com/Decathlon/wiki-page-creator-action/issues/11)
- We can't reference images with a relative path

So to solve both of these, we created our own solution, based from the following: [github-wiki-action](https://github.com/Andrew-Chen-Wang/github-wiki-action) 🚀

## Insight 📝

The Wiki for this repository is stored [here](https://github.com/nimblehq/android-templates/wiki), meaning it's independent of [our code](https://github.com/nimblehq/android-templates).   

Let's break down the steps, but keep in mind that action is only triggered if `main` branch AND `docs` were updated:

1. Create a temporary folder: `tmp_wiki`
2. Initialize Git
3. Pull [Wiki content](https://github.com/nimblehq/android-templates.wiki.git) in to the temporary folder
4. Synchronize changes between `docs` & `tmp_wiki` > By using the `rsync` command
5. Add, commit & push
6. Show commit in the [history](https://github.com/nimblehq/android-templates/wiki/_history)

## Proof Of Work 📹

I have not been able to test it locally on this repository, but please let me know if there's a way 🙇 

Anyhow, I did experiment, test and verify these changes on my [own repository ](https://github.com/Tuubz/WikiPlayground). Please check it out 🚀 