### PR TITLE
[#83] Setup the unit testing part for Coroutine Template

### DIFF
--- a/CoroutineTemplate/app/build.gradle.kts
+++ b/CoroutineTemplate/app/build.gradle.kts
@@ -56,6 +56,10 @@ android {
         create(Flavor.PRODUCTION) {}
     }
 
+    sourceSets["test"].resources {
+        srcDir("src/test/resources")
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
@@ -80,6 +84,18 @@ android {
         xmlReport = true
         xmlOutput = file("build/reports/lint/lint-result.xml")
     }
+
+    testOptions {
+        unitTests {
+            // Robolectric resource processing/loading
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
+    }
+}
+
+kapt {
+    correctErrorTypes = true
 }
 
 dependencies {
@@ -111,4 +127,22 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.KOTLINX_COROUTINES_VERSION}")
 
     kapt("com.google.dagger:hilt-compiler:${Versions.HILT_VERSION}")
+
+    debugImplementation("androidx.fragment:fragment-testing:${Versions.ANDROID_FRAGMENT_VERSION}")
+
+    // Testing
+    testImplementation("io.kotest:kotest-assertions-core:${Versions.TEST_KOTEST_VERSION}")
+    testImplementation("junit:junit:${Versions.TEST_JUNIT_VERSION}")
+    testImplementation("org.robolectric:shadowapi:${Versions.TEST_ROBOLECTRIC_VERSION}")
+    testImplementation("org.robolectric:robolectric:${Versions.TEST_ROBOLECTRIC_VERSION}")
+    testImplementation("androidx.test:core:${Versions.ANDROIDX_CORE_KTX_VERSION}")
+    testImplementation("androidx.test:runner:${Versions.TEST_RUNNER_VERSION}")
+    testImplementation("androidx.test:rules:${Versions.TEST_RUNNER_VERSION}")
+    testImplementation("androidx.test.ext:junit-ktx:${Versions.TEST_JUNIT_ANDROIDX_EXT_VERSION}")
+    testImplementation("com.google.dagger:hilt-android-testing:${Versions.HILT_VERSION}")
+    testImplementation("org.jetbrains.kotlin:kotlin-reflect:${Versions.KOTLIN_REFLECT_VERSION}")
+    testImplementation("io.mockk:mockk:${Versions.TEST_MOCKK_VERSION}")
+
+    kaptTest("com.google.dagger:hilt-android-compiler:${Versions.HILT_VERSION}")
+    testAnnotationProcessor("com.google.dagger:hilt-android-compiler:${Versions.HILT_VERSION}")
 }

--- a/CoroutineTemplate/app/build.gradle.kts
+++ b/CoroutineTemplate/app/build.gradle.kts
@@ -128,12 +128,11 @@ dependencies {
 
     kapt("com.google.dagger:hilt-compiler:${Versions.HILT_VERSION}")
 
-    debugImplementation("androidx.fragment:fragment-testing:${Versions.ANDROID_FRAGMENT_VERSION}")
+    debugImplementation("androidx.fragment:fragment-testing:${Versions.ANDROIDX_FRAGMENT_VERSION}")
 
     // Testing
     testImplementation("io.kotest:kotest-assertions-core:${Versions.TEST_KOTEST_VERSION}")
     testImplementation("junit:junit:${Versions.TEST_JUNIT_VERSION}")
-    testImplementation("org.robolectric:shadowapi:${Versions.TEST_ROBOLECTRIC_VERSION}")
     testImplementation("org.robolectric:robolectric:${Versions.TEST_ROBOLECTRIC_VERSION}")
     testImplementation("androidx.test:core:${Versions.ANDROIDX_CORE_KTX_VERSION}")
     testImplementation("androidx.test:runner:${Versions.TEST_RUNNER_VERSION}")

--- a/CoroutineTemplate/app/src/debug/AndroidManifest.xml
+++ b/CoroutineTemplate/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="co.nimblehq.coroutine">
+
+    <application>
+        <activity
+            android:name=".EmptyHiltActivity"
+            android:exported="false" />
+    </application>
+
+</manifest>

--- a/CoroutineTemplate/app/src/debug/java/co/nimblehq/coroutine/EmptyHiltActivity.kt
+++ b/CoroutineTemplate/app/src/debug/java/co/nimblehq/coroutine/EmptyHiltActivity.kt
@@ -1,0 +1,7 @@
+package co.nimblehq.coroutine
+
+import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class EmptyHiltActivity : AppCompatActivity()

--- a/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/extension/ViewModelExt.kt
+++ b/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/extension/ViewModelExt.kt
@@ -1,0 +1,40 @@
+package co.nimblehq.coroutine.extension
+
+import androidx.activity.ComponentActivity
+import androidx.activity.viewModels
+import androidx.annotation.MainThread
+import androidx.fragment.app.*
+import androidx.lifecycle.*
+
+/**
+ * PLEASE READ THIS BEFORE IMPLEMENT:
+ * Right now, there is no easy way to mock/ fake the viewModel inside the Fragment when applying
+ * the 'by viewModels()' Kotlin property delegate from the activity-ktx/ fragment-ktx artifact.
+ * After finding many ways to handle this issue, I end up with this solution that is to override the
+ * loading mechanism of the delegate.
+ * There is another way to resolve the issue as well and it is mentioned in the reference link.
+ * Reference: https://proandroiddev.com/testing-the-untestable-the-case-of-the-viewmodel-delegate-975c09160993
+ */
+@MainThread
+inline fun <reified VM : ViewModel> Fragment.provideActivityViewModels(
+    noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
+): Lazy<VM> = OverridableLazy(activityViewModels(factoryProducer))
+
+@MainThread
+inline fun <reified VM : ViewModel> Fragment.provideViewModels(
+    noinline ownerProducer: () -> ViewModelStoreOwner = { this },
+    noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
+): Lazy<VM> = OverridableLazy(viewModels(ownerProducer, factoryProducer))
+
+@MainThread
+inline fun <reified VM : ViewModel> ComponentActivity.provideViewModels(
+    noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
+): Lazy<VM> = OverridableLazy(viewModels(factoryProducer))
+
+class OverridableLazy<T>(var implementation: Lazy<T>) : Lazy<T> {
+
+    override val value
+        get() = implementation.value
+
+    override fun isInitialized() = implementation.isInitialized()
+}

--- a/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/ui/base/BaseFragment.kt
+++ b/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/ui/base/BaseFragment.kt
@@ -28,7 +28,7 @@ abstract class BaseFragment<VB : ViewBinding> : Fragment(), BaseFragmentCallback
     private var _binding: ViewBinding? = null
 
     @Suppress("UNCHECKED_CAST")
-    protected val binding: VB
+    val binding: VB
         get() = _binding as VB
 
     @CallSuper

--- a/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/ui/screens/home/HomeFragment.kt
+++ b/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/ui/screens/home/HomeFragment.kt
@@ -2,7 +2,6 @@ package co.nimblehq.coroutine.ui.screens.home
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.fragment.app.viewModels
 import co.nimblehq.coroutine.databinding.FragmentHomeBinding
 import co.nimblehq.coroutine.databinding.ViewLoadingBinding
 import co.nimblehq.coroutine.extension.provideViewModels

--- a/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/ui/screens/home/HomeFragment.kt
+++ b/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/ui/screens/home/HomeFragment.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import co.nimblehq.coroutine.databinding.FragmentHomeBinding
 import co.nimblehq.coroutine.databinding.ViewLoadingBinding
+import co.nimblehq.coroutine.extension.provideViewModels
 import co.nimblehq.coroutine.extension.visibleOrGone
 import co.nimblehq.coroutine.lib.IsLoading
 import co.nimblehq.coroutine.model.UserUiModel
@@ -21,7 +22,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     @Inject
     lateinit var navigator: MainNavigator
 
-    private val viewModel: HomeViewModel by viewModels()
+    private val viewModel: HomeViewModel by provideViewModels()
 
     private lateinit var viewLoadingBinding: ViewLoadingBinding
 

--- a/CoroutineTemplate/app/src/test/java/co/nimblehq/coroutine/test/TestModules.kt
+++ b/CoroutineTemplate/app/src/test/java/co/nimblehq/coroutine/test/TestModules.kt
@@ -1,0 +1,21 @@
+package co.nimblehq.coroutine.test
+
+import co.nimblehq.coroutine.di.modules.NavigatorModule
+import co.nimblehq.coroutine.ui.screens.MainNavigator
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.android.components.FragmentComponent
+import dagger.hilt.testing.TestInstallIn
+import io.mockk.mockk
+
+@Module
+@TestInstallIn(
+    components = [FragmentComponent::class],
+    replaces = [NavigatorModule::class]
+)
+object TestNavigatorModule {
+    val mockMainNavigator = mockk<MainNavigator>()
+
+    @Provides
+    fun provideMainNavigator() = mockMainNavigator
+}

--- a/CoroutineTemplate/app/src/test/java/co/nimblehq/coroutine/test/ViewModelExt.kt
+++ b/CoroutineTemplate/app/src/test/java/co/nimblehq/coroutine/test/ViewModelExt.kt
@@ -1,0 +1,21 @@
+package co.nimblehq.coroutine.test
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import co.nimblehq.coroutine.extension.OverridableLazy
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
+fun <VM : ViewModel, T> T.replace(
+    viewModelDelegate: KProperty1<T, VM>,
+    viewModel: VM
+) {
+    viewModelDelegate.isAccessible = true
+    (viewModelDelegate.getDelegate(this) as OverridableLazy<VM>).implementation = lazy { viewModel }
+}
+
+inline fun <reified T : Fragment, VM> T.getPrivateProperty(name: String): KProperty1<T, VM> =
+    T::class
+        .memberProperties
+        .first { it.name == name } as KProperty1<T, VM>

--- a/CoroutineTemplate/app/src/test/java/co/nimblehq/coroutine/ui/BaseFragmentTest.kt
+++ b/CoroutineTemplate/app/src/test/java/co/nimblehq/coroutine/ui/BaseFragmentTest.kt
@@ -1,0 +1,69 @@
+package co.nimblehq.coroutine.ui
+
+import android.content.ComponentName
+import android.content.Intent
+import android.os.Bundle
+import androidx.annotation.StyleRes
+import androidx.core.util.Preconditions
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.viewbinding.ViewBinding
+import co.nimblehq.coroutine.EmptyHiltActivity
+import co.nimblehq.coroutine.R
+import co.nimblehq.coroutine.ui.base.BaseFragment
+import dagger.hilt.android.testing.*
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+abstract class BaseFragmentTest<F : BaseFragment<VB>, VB : ViewBinding> {
+
+    protected lateinit var fragment: F
+
+    /**
+     * Issue: launchFragmentInContainer from the androidx.fragment:fragment-testing library
+     * is NOT possible to use right now as it uses a hardcoded Activity under the hood
+     * (i.e. [EmptyFragmentActivity]) which is not annotated with @AndroidEntryPoint.
+     *
+     * As a workaround, use this function that is equivalent. It requires you to add
+     * [HiltTestActivity] in the debug folder and include it in the debug AndroidManifest.xml file
+     * as can be found in this project.
+     * Read more: https://dagger.dev/hilt/testing
+     * Solution: launchFragmentInHiltContainer is copied from architecture-sample repo, but has
+     * been modified to receive input [onInstantiate] so the devs can create the fragment
+     * instance with mock/ fake variables at the initial step.
+     * Reference: https://github.com/android/architecture-samples/blob/dev-hilt/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/HiltExt.kt
+     */
+    protected inline fun <reified F : BaseFragment<VB>> launchFragmentInHiltContainer(
+        crossinline onInstantiate: F.() -> Unit,
+        fragmentArgs: Bundle? = null,
+        @StyleRes themeResId: Int = R.style.FragmentScenarioEmptyFragmentActivityTheme,
+        crossinline action: F.() -> Unit = {}
+    ) {
+        val startActivityIntent = Intent.makeMainActivity(
+            ComponentName(
+                ApplicationProvider.getApplicationContext(),
+                EmptyHiltActivity::class.java
+            )
+        ).putExtra(
+            "androidx.fragment.app.testing.FragmentScenario.EmptyFragmentActivity.THEME_EXTRAS_BUNDLE_KEY",
+            themeResId
+        )
+
+        ActivityScenario.launch<EmptyHiltActivity>(startActivityIntent).onActivity { activity ->
+            val fragment = (activity.supportFragmentManager.fragmentFactory.instantiate(
+                Preconditions.checkNotNull(F::class.java.classLoader),
+                F::class.java.name
+            ) as F).apply {
+                this.onInstantiate()
+            }
+            fragment.arguments = fragmentArgs
+            activity.supportFragmentManager
+                .beginTransaction()
+                .add(android.R.id.content, fragment, "")
+                .commitNow()
+
+            fragment.action()
+        }
+    }
+}

--- a/CoroutineTemplate/app/src/test/java/co/nimblehq/coroutine/ui/screens/home/HomeFragmentTest.kt
+++ b/CoroutineTemplate/app/src/test/java/co/nimblehq/coroutine/ui/screens/home/HomeFragmentTest.kt
@@ -1,0 +1,45 @@
+package co.nimblehq.coroutine.ui.screens.home
+
+import co.nimblehq.coroutine.databinding.FragmentHomeBinding
+import co.nimblehq.coroutine.test.TestNavigatorModule.mockMainNavigator
+import co.nimblehq.coroutine.test.getPrivateProperty
+import co.nimblehq.coroutine.test.replace
+import co.nimblehq.coroutine.ui.BaseFragmentTest
+import dagger.hilt.android.testing.*
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.*
+
+@HiltAndroidTest
+class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
+
+    private val mockViewModel = mockk<HomeViewModel>(relaxed = true)
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun `When initializing HomeFragment, its views display the text correctly`() {
+        launchFragment()
+        fragment.binding.btNext.text.toString() shouldBe "Next"
+        fragment.binding.btCompose.text.toString() shouldBe "Jetpack Compose"
+    }
+
+    private fun launchFragment() {
+        launchFragmentInHiltContainer<HomeFragment>(
+            onInstantiate = {
+                replace(getPrivateProperty("viewModel"), mockViewModel)
+                navigator = mockMainNavigator
+            }
+        ) {
+            fragment = this
+            fragment.navigator.shouldNotBeNull()
+        }
+    }
+}

--- a/CoroutineTemplate/app/src/test/resources/robolectric.properties
+++ b/CoroutineTemplate/app/src/test/resources/robolectric.properties
@@ -1,0 +1,2 @@
+sdk=28
+application=dagger.hilt.android.testing.HiltTestApplication

--- a/CoroutineTemplate/buildSrc/src/main/java/Versions.kt
+++ b/CoroutineTemplate/buildSrc/src/main/java/Versions.kt
@@ -12,6 +12,7 @@ object Versions {
     const val ANDROID_CRYPTO_VERSION = "1.0.0"
     const val ANDROIDX_ACTIVITY_KTX_VERSION = "1.2.1"
     const val ANDROIDX_CORE_KTX_VERSION = "1.3.0"
+    const val ANDROID_FRAGMENT_VERSION = "1.3.3"
     const val ANDROIDX_LIFECYCLE_VERSION = "2.4.0-alpha02"
     const val ANDROIDX_NAVIGATION_VERSION = "2.3.4"
     const val ANDROIDX_SUPPORT_VERSION = "1.3.0"
@@ -25,6 +26,7 @@ object Versions {
 
     const val KOTLIN_VERSION = "1.5.21"
     const val KOTLINX_COROUTINES_VERSION = "1.5.0"
+    const val KOTLIN_REFLECT_VERSION = "1.5.10"
 
     const val MOSHI_VERSION = "1.12.0"
 
@@ -35,4 +37,12 @@ object Versions {
 
     // Configuration
     const val DETEKT_VERSION = "1.18.1"
+
+    // Testing libraries
+    const val TEST_JUNIT_VERSION = "4.13.2"
+    const val TEST_JUNIT_ANDROIDX_EXT_VERSION = "1.1.2"
+    const val TEST_KOTEST_VERSION = "4.6.3"
+    const val TEST_MOCKK_VERSION = "1.10.6"
+    const val TEST_ROBOLECTRIC_VERSION = "4.3.1"
+    const val TEST_RUNNER_VERSION = "1.3.0"
 }

--- a/CoroutineTemplate/buildSrc/src/main/java/Versions.kt
+++ b/CoroutineTemplate/buildSrc/src/main/java/Versions.kt
@@ -12,7 +12,7 @@ object Versions {
     const val ANDROID_CRYPTO_VERSION = "1.0.0"
     const val ANDROIDX_ACTIVITY_KTX_VERSION = "1.2.1"
     const val ANDROIDX_CORE_KTX_VERSION = "1.3.0"
-    const val ANDROID_FRAGMENT_VERSION = "1.3.3"
+    const val ANDROIDX_FRAGMENT_VERSION = "1.3.3"
     const val ANDROIDX_LIFECYCLE_VERSION = "2.4.0-alpha02"
     const val ANDROIDX_NAVIGATION_VERSION = "2.3.4"
     const val ANDROIDX_SUPPORT_VERSION = "1.3.0"
@@ -24,9 +24,9 @@ object Versions {
 
     const val JAVAX_INJECT_VERSION = "1"
 
+    const val KOTLIN_REFLECT_VERSION = "1.5.10"
     const val KOTLIN_VERSION = "1.5.21"
     const val KOTLINX_COROUTINES_VERSION = "1.5.0"
-    const val KOTLIN_REFLECT_VERSION = "1.5.10"
 
     const val MOSHI_VERSION = "1.12.0"
 
@@ -39,8 +39,8 @@ object Versions {
     const val DETEKT_VERSION = "1.18.1"
 
     // Testing libraries
-    const val TEST_JUNIT_VERSION = "4.13.2"
     const val TEST_JUNIT_ANDROIDX_EXT_VERSION = "1.1.2"
+    const val TEST_JUNIT_VERSION = "4.13.2"
     const val TEST_KOTEST_VERSION = "4.6.3"
     const val TEST_MOCKK_VERSION = "1.10.6"
     const val TEST_ROBOLECTRIC_VERSION = "4.3.1"


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/83

## What happened 👀

We haven't written any unit testing part for the presentation layer. This PR is to set up all necessary pieces so we can easily write the unit test for Fragment/ Activity later.

## Insight 📝

Continue the work for CoroutineTemplate from #137 

## Proof Of Work 📹

https://user-images.githubusercontent.com/60863885/139396980-7a5fa194-e239-4c42-bc1c-18e67f56dadb.mov

