### PR TITLE
[#146] Add RFC template

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc_template.md
+++ b/.github/ISSUE_TEMPLATE/rfc_template.md
@@ -1,0 +1,28 @@
+---
+name: "Request For Comments (RFC)"
+about: "You have an idea on how to improve our processes. Propose your idea so that the team can provide feedback."
+title: "RFC: "
+labels: "type : rfc"
+---
+
+## Issue
+
+Describe the issue the team is currently facing. Provide as much content as possible.
+
+## Solution
+
+Describe the solution you are prescribing for the issue
+
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, specific chapters, clients...
+
+## What's Next?
+
+Provide an actionable list of things that must happen in order to implement the solution:
+
+- [ ]
+- [ ]
+- [ ]
+
+Using a poll is encouraged to gather feedback on the RFA 👉 Use this tool: https://gh-polls.com/


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/146

## What happened 👀

Following the Compass repository, there is a template for creating the RFC when the issue needs to be voted for agreement by the team. Android repository is lacking this template.

## Insight 📝

Copy RFC template from [compass repository](https://github.com/nimblehq/compass/blob/development/.github/ISSUE_TEMPLATE/rfc_template.md)

## Proof Of Work 📹

The RFC should be shown when creating a new issue
