### PR TITLE
[#133] Adding the test step for the newproject.sh test script

### DIFF
--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -1,0 +1,40 @@
+name: Verify newproject script
+
+on:
+  pull_request:
+    types: [ opened, edited, reopened, synchronize ]
+    branches:
+      - 'feature/**'
+      - 'chore/**'
+      - 'bug/**'
+
+jobs:
+  verify_newproject_script:
+    name: Verify newproject script
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Checkout source code
+        uses: actions/checkout@v2.3.2
+
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Verify generating new project from RxTemplate
+        run: ./newproject.sh -t rx -p co.myproject.example -n "MyProjectExampleRx"
+
+      - name: Verify generating new project from CoroutineTemplate
+        run: ./newproject.sh -t crt -p co.myproject.example -n "MyProjectExampleCoroutine"

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -2,7 +2,7 @@ name: Verify newproject script
 
 on:
   pull_request:
-    types: [ opened, edited, reopened, synchronize ]
+    types: [ opened, reopened, synchronize ]
     branches: [ develop ]
 
 jobs:

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -3,10 +3,7 @@ name: Verify newproject script
 on:
   pull_request:
     types: [ opened, edited, reopened, synchronize ]
-    branches:
-      - 'feature/**'
-      - 'chore/**'
-      - 'bug/**'
+    branches: [ develop ]
 
 jobs:
   verify_newproject_script:

--- a/newproject.sh
+++ b/newproject.sh
@@ -108,13 +108,13 @@ NAME_NO_SPACES=$(echo "$appname" | sed "s/ //g")
 # Copy main folder
 cp -R $OLD_NAME $NAME_NO_SPACES
 
-# clean the old build
+# Clean the old build
 ./$NAME_NO_SPACES/gradlew -p ./$NAME_NO_SPACES clean
-# get rid of idea settings
+# Get rid of idea settings
 rm -rf $NAME_NO_SPACES/.idea
-# get rid of gradle cache
+# Get rid of gradle cache
 rm -rf $NAME_NO_SPACES/.gradle
-# get rid of the git history
+# Get rid of the git history
 rm -rf $NAME_NO_SPACES/.git
 
 # Rename folder structure

--- a/newproject.sh
+++ b/newproject.sh
@@ -108,15 +108,14 @@ NAME_NO_SPACES=$(echo "$appname" | sed "s/ //g")
 # Copy main folder
 cp -R $OLD_NAME $NAME_NO_SPACES
 
+# clean the old build
+./$NAME_NO_SPACES/gradlew -p ./$NAME_NO_SPACES clean
 # get rid of idea settings
 rm -rf $NAME_NO_SPACES/.idea
 # get rid of gradle cache
 rm -rf $NAME_NO_SPACES/.gradle
 # get rid of the git history
 rm -rf $NAME_NO_SPACES/.git
-# get rid of the build
-rm -rf $NAME_NO_SPACES/build
-rm -rf $NAME_NO_SPACES/app/build
 
 # Rename folder structure
 renameFolderStructure() {
@@ -155,12 +154,6 @@ DATA_PACKAGE_DIR=$( renameFolderStructure $DATA_PACKAGE_DIR )
 DOMAIN_PACKAGE_DIR="domain/src/main/java"
 DOMAIN_PACKAGE_DIR=$( renameFolderStructure $DOMAIN_PACKAGE_DIR )
 
-if [ $template = "rx" ]
-then
-  COMMON_RX_PACKAGE_DIR="common-rx/src/main/java"
-  COMMON_RX_PACKAGE_DIR=$( renameFolderStructure $COMMON_RX_PACKAGE_DIR )
-fi
-
 # Rename android test folder structure
 APP_ANDROIDTEST_DIR="app/src/androidTest/java"
 if [ -d APP_ANDROIDTEST_DIR ]
@@ -178,15 +171,6 @@ DOMAIN_ANDROIDTEST_DIR="domain/src/androidTest/java"
 if [ -d DOMAIN_ANDROIDTEST_DIR ]
 then
     DOMAIN_ANDROIDTEST_DIR=$( renameFolderStructure $DOMAIN_ANDROIDTEST_DIR )
-fi
-
-if [ $template = "rx" ]
-then
-  COMMON_RX_ANDROIDTEST_DIR="common-rx/src/androidTest/java"
-  if [ -d COMMON_RX_ANDROIDTEST_DIR ]
-  then
-      COMMON_RX_ANDROIDTEST_DIR=$( renameFolderStructure $COMMON_RX_ANDROIDTEST_DIR )
-  fi
 fi
 
 # Rename test folder structure
@@ -208,8 +192,21 @@ then
     DOMAIN_TEST_DIR=$( renameFolderStructure $DOMAIN_TEST_DIR )
 fi
 
+# Rename common-rx module on RxTemplate
 if [ $template = "rx" ]
 then
+  # Rename package folder
+  COMMON_RX_PACKAGE_DIR="common-rx/src/main/java"
+  COMMON_RX_PACKAGE_DIR=$( renameFolderStructure $COMMON_RX_PACKAGE_DIR )
+
+  # Rename androidTest folder
+  COMMON_RX_ANDROIDTEST_DIR="common-rx/src/androidTest/java"
+  if [ -d COMMON_RX_ANDROIDTEST_DIR ]
+  then
+      COMMON_RX_ANDROIDTEST_DIR=$( renameFolderStructure $COMMON_RX_ANDROIDTEST_DIR )
+  fi
+
+  # Rename test folder
   COMMON_RX_TEST_DIR="common-rx/src/test/java"
   if [ -d COMMON_RX_TEST_DIR ]
   then
@@ -223,7 +220,7 @@ echo "✅  Completed"
 echo "=> 🔎 Replacing package and package name within files..."
 PACKAGE_NAME_ESCAPED="${packagename//./\.}"
 OLD_PACKAGE_NAME_ESCAPED="${OLD_PACKAGE//./\.}"
-if [[ "$OSTYPE" == "darwin"* ]] #MacOS
+if [[ "$OSTYPE" == "darwin"* ]] # Mac OSX
 then
   LC_ALL=C find $WORKING_DIR/$NAME_NO_SPACES -type f -exec sed -i "" -e "s/$OLD_PACKAGE_NAME_ESCAPED/$PACKAGE_NAME_ESCAPED/g" {} +
   LC_ALL=C find $WORKING_DIR/$NAME_NO_SPACES -type f -exec sed -i "" -e "s/$OLD_NAME/$NAME_NO_SPACES/g" {} +
@@ -235,7 +232,7 @@ echo "✅  Completed"
 
 # Search and replace files <...>
 echo "=> 🔎 Replacing app name in strings.xml..."
-if [[ "$OSTYPE" == "darwin"* ]] #MacOS
+if [[ "$OSTYPE" == "darwin"* ]] # Mac OSX
 then
   sed -i "" -e "s/$OLD_APPNAME/$appname/" "$WORKING_DIR/$NAME_NO_SPACES/app/src/main/res/values/strings.xml"
   sed -i "" -e "s/$OLD_APPNAME/$appname/" "$WORKING_DIR/$NAME_NO_SPACES/app/src/staging/res/values/strings.xml"
@@ -252,12 +249,11 @@ mv $OLD_APPLICATION_CLASS_PATH $APPLICATION_CLASS_PATH
 echo "✅  Completed"
 
 echo "=> 🛠️ Building generated project..."
-cd $appname
-./gradlew assembleDebug
+./$NAME_NO_SPACES/gradlew -p ./$NAME_NO_SPACES assembleDebug
 echo "✅  Build success"
 
 echo "=> 🚓 Executing all unittest..."
-./gradlew testStagingDebugUnitTest
+./$NAME_NO_SPACES/gradlew -p ./$NAME_NO_SPACES testStagingDebugUnitTest
 echo "✅  All test passed"
 
 # Done!

--- a/newproject.sh
+++ b/newproject.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # Script inspired by https://gist.github.com/szeidner/613fe4652fc86f083cefa21879d5522b
@@ -96,7 +96,7 @@ fi
 
 # Enforce package name
 regex='^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+[0-9a-z_]$'
-if ! [[ $packagename =~ $regex ]]; then
+if ! [[ "$packagename" =~ $regex ]]; then
     die "Invalid Package Name: $packagename (needs to follow standard pattern {com.example.package})"
 fi
 
@@ -223,14 +223,26 @@ echo "✅  Completed"
 echo "=> 🔎 Replacing package and package name within files..."
 PACKAGE_NAME_ESCAPED="${packagename//./\.}"
 OLD_PACKAGE_NAME_ESCAPED="${OLD_PACKAGE//./\.}"
-LC_ALL=C find $WORKING_DIR/$NAME_NO_SPACES -type f -exec sed -i "" "s/$OLD_PACKAGE_NAME_ESCAPED/$PACKAGE_NAME_ESCAPED/g" {} +
-LC_ALL=C find $WORKING_DIR/$NAME_NO_SPACES -type f -exec sed -i "" "s/$OLD_NAME/$NAME_NO_SPACES/g" {} +
+if [[ "$OSTYPE" == "darwin"* ]] #MacOS
+then
+  LC_ALL=C find $WORKING_DIR/$NAME_NO_SPACES -type f -exec sed -i "" -e "s/$OLD_PACKAGE_NAME_ESCAPED/$PACKAGE_NAME_ESCAPED/g" {} +
+  LC_ALL=C find $WORKING_DIR/$NAME_NO_SPACES -type f -exec sed -i "" -e "s/$OLD_NAME/$NAME_NO_SPACES/g" {} +
+else
+  LC_ALL=C find $WORKING_DIR/$NAME_NO_SPACES -type f -exec sed -i -e "s/$OLD_PACKAGE_NAME_ESCAPED/$PACKAGE_NAME_ESCAPED/g" {} +
+  LC_ALL=C find $WORKING_DIR/$NAME_NO_SPACES -type f -exec sed -i -e "s/$OLD_NAME/$NAME_NO_SPACES/g" {} +
+fi
 echo "✅  Completed"
 
 # Search and replace files <...>
 echo "=> 🔎 Replacing app name in strings.xml..."
-sed -i "" "s/$OLD_APPNAME/$appname/" "$WORKING_DIR/$NAME_NO_SPACES/app/src/main/res/values/strings.xml"
-sed -i "" "s/$OLD_APPNAME/$appname/" "$WORKING_DIR/$NAME_NO_SPACES/app/src/staging/res/values/strings.xml"
+if [[ "$OSTYPE" == "darwin"* ]] #MacOS
+then
+  sed -i "" -e "s/$OLD_APPNAME/$appname/" "$WORKING_DIR/$NAME_NO_SPACES/app/src/main/res/values/strings.xml"
+  sed -i "" -e "s/$OLD_APPNAME/$appname/" "$WORKING_DIR/$NAME_NO_SPACES/app/src/staging/res/values/strings.xml"
+else
+  sed -i -e "s/$OLD_APPNAME/$appname/" "$WORKING_DIR/$NAME_NO_SPACES/app/src/main/res/values/strings.xml"
+  sed -i -e "s/$OLD_APPNAME/$appname/" "$WORKING_DIR/$NAME_NO_SPACES/app/src/staging/res/values/strings.xml"
+fi
 echo "✅  Completed"
 
 echo "=> 🔎 Replacing Application class..."

--- a/newproject.sh
+++ b/newproject.sh
@@ -146,21 +146,75 @@ renameFolderStructure() {
 echo "=> 🔎 Replacing files structure..."
 
 # Rename project folder structure
-PACKAGE_DIR="app/src/main/java"
-PACKAGE_DIR=$( renameFolderStructure $PACKAGE_DIR )
+APP_PACKAGE_DIR="app/src/main/java"
+APP_PACKAGE_DIR=$( renameFolderStructure $APP_PACKAGE_DIR )
+
+DATA_PACKAGE_DIR="data/src/main/java"
+DATA_PACKAGE_DIR=$( renameFolderStructure $DATA_PACKAGE_DIR )
+
+DOMAIN_PACKAGE_DIR="domain/src/main/java"
+DOMAIN_PACKAGE_DIR=$( renameFolderStructure $DOMAIN_PACKAGE_DIR )
+
+if [ $template = "rx" ]
+then
+  COMMON_RX_PACKAGE_DIR="common-rx/src/main/java"
+  COMMON_RX_PACKAGE_DIR=$( renameFolderStructure $COMMON_RX_PACKAGE_DIR )
+fi
 
 # Rename android test folder structure
-ANDROIDTEST_DIR="app/src/androidTest/java"
-if [ -d ANDROIDTEST_DIR ]
+APP_ANDROIDTEST_DIR="app/src/androidTest/java"
+if [ -d APP_ANDROIDTEST_DIR ]
 then
-    ANDROIDTEST_DIR=$( renameFolderStructure $ANDROIDTEST_DIR )
+    APP_ANDROIDTEST_DIR=$( renameFolderStructure $APP_ANDROIDTEST_DIR )
+fi
+
+DATA_ANDROIDTEST_DIR="data/src/androidTest/java"
+if [ -d DATA_ANDROIDTEST_DIR ]
+then
+    DATA_ANDROIDTEST_DIR=$( renameFolderStructure $DATA_ANDROIDTEST_DIR )
+fi
+
+DOMAIN_ANDROIDTEST_DIR="domain/src/androidTest/java"
+if [ -d DOMAIN_ANDROIDTEST_DIR ]
+then
+    DOMAIN_ANDROIDTEST_DIR=$( renameFolderStructure $DOMAIN_ANDROIDTEST_DIR )
+fi
+
+if [ $template = "rx" ]
+then
+  COMMON_RX_ANDROIDTEST_DIR="common-rx/src/androidTest/java"
+  if [ -d COMMON_RX_ANDROIDTEST_DIR ]
+  then
+      COMMON_RX_ANDROIDTEST_DIR=$( renameFolderStructure $COMMON_RX_ANDROIDTEST_DIR )
+  fi
 fi
 
 # Rename test folder structure
-TEST_DIR="app/src/test/java"
-if [ -d TEST_DIR ]
+APP_TEST_DIR="app/src/test/java"
+if [ -d APP_TEST_DIR ]
 then
-    TEST_DIR=$( renameFolderStructure TEST_DIR )
+    APP_TEST_DIR=$( renameFolderStructure $APP_TEST_DIR )
+fi
+
+DATA_TEST_DIR="data/src/test/java"
+if [ -d DATA_TEST_DIR ]
+then
+    DATA_TEST_DIR=$( renameFolderStructure $DATA_TEST_DIR )
+fi
+
+DOMAIN_TEST_DIR="domain/src/test/java"
+if [ -d DOMAIN_TEST_DIR ]
+then
+    DOMAIN_TEST_DIR=$( renameFolderStructure $DOMAIN_TEST_DIR )
+fi
+
+if [ $template = "rx" ]
+then
+  COMMON_RX_TEST_DIR="common-rx/src/test/java"
+  if [ -d COMMON_RX_TEST_DIR ]
+  then
+      COMMON_RX_TEST_DIR=$( renameFolderStructure $COMMON_RX_TEST_DIR )
+  fi
 fi
 
 echo "✅  Completed"
@@ -185,5 +239,14 @@ APPLICATION_CLASS_PATH="${OLD_APPLICATION_CLASS_PATH/$OLD_NAME/$NAME_NO_SPACES}"
 mv $OLD_APPLICATION_CLASS_PATH $APPLICATION_CLASS_PATH
 echo "✅  Completed"
 
+echo "=> 🛠️ Building generated project..."
+cd $appname
+./gradlew assembleDebug
+echo "✅  Build success"
+
+echo "=> 🚓 Executing all unittest..."
+./gradlew testStagingDebugUnitTest
+echo "✅  All test passed"
+
 # Done!
-echo "=> 🚀 Done! App is ready to be tested 🙌"
+echo "=> 🚀 Done! The project is ready for development 🙌"

--- a/newproject.sh
+++ b/newproject.sh
@@ -252,9 +252,9 @@ echo "=> 🛠️ Building generated project..."
 ./$NAME_NO_SPACES/gradlew -p ./$NAME_NO_SPACES assembleDebug
 echo "✅  Build success"
 
-echo "=> 🚓 Executing all unittest..."
+echo "=> 🚓 Executing all unit tests..."
 ./$NAME_NO_SPACES/gradlew -p ./$NAME_NO_SPACES testStagingDebugUnitTest
-echo "✅  All test passed"
+echo "✅  All unit tests passed"
 
 # Done!
 echo "=> 🚀 Done! The project is ready for development 🙌"


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/133

## What happened 👀

As we discussed recently in the Retrospective Meeting, the current process to initialize a project via the newproject.sh script is not being tested when the CI runs. This causes us into trouble when there are changes under the hood of the template implementation that breaks the script or are executed but the project is not buildable.

The solution does not only do we run the unit test on the template like a normal project, but we have to also test our init script that works as expected.

## Insight 📝

Here is the solution to verify `newproject.sh` script:
- Firstly, I added `gradle` command to build the project and execute UnitTest on the generated project to make sure the script works properly.
- The second step is adding a new workflow to execute `newproject.sh` for 2 templates on Github Actions.

## Proof Of Work 📹

- All checks should be passed ✅ 

- Executing script on local

https://user-images.githubusercontent.com/6950766/146744440-b565e0ec-dab6-407d-bff8-09050ea8b5f3.mov


