### PR TITLE
[#155] Replace `jCenter()` with `mavenCentral()`

### DIFF
--- a/RxJavaTemplate/build.gradle.kts
+++ b/RxJavaTemplate/build.gradle.kts
@@ -3,7 +3,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -21,7 +21,6 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
         maven(url = "https://jitpack.io")
         mavenCentral()
     }

--- a/RxJavaTemplate/buildSrc/src/main/java/Versions.kt
+++ b/RxJavaTemplate/buildSrc/src/main/java/Versions.kt
@@ -49,7 +49,7 @@ object Versions {
     const val TEST_ESPRESSO_VERSION = "3.3.0"
     const val TEST_JUNIT_VERSION = "4.13.2"
     const val TEST_JUNIT_ANDROIDX_EXT_VERSION = "1.1.2"
-    const val TEST_KLUENT_VERSION = "1.60"
+    const val TEST_KLUENT_VERSION = "1.64"
     const val TEST_MOCKK_VERSION = "1.10.6"
     const val TEST_MOCKITO_VERSION = "3.2.0"
     const val TEST_MOCKITO_DEXMAKER_VERSION = "2.28.1"
@@ -57,5 +57,5 @@ object Versions {
     const val TEST_RUNNER_VERSION = "1.3.0"
 
     // Configuration
-    const val DETEKT_VERSION = "1.14.0"
+    const val DETEKT_VERSION = "1.18.1"
 }


### PR DESCRIPTION
#155 

## What happened 👀

- JCenter is deprecated, so replace it with MavenCentral. 
- Upgrade dependency versions to resolve CI issue caused by migration

## Insight 📝

Only make this change for RxJavaTemplate, as it's already integrated for CourotineTemplate

## Proof Of Work 📹

https://user-images.githubusercontent.com/18277915/159412531-cc27b904-bf45-4fad-8754-93d125d59963.mp4
