### PR TITLE
[#165] Fix Github Actions error

### DIFF
--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout source code
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
 
       - name: Pull content from Wiki
         run: |

--- a/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.github/workflows/run_detekt_and_unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: 1.8
 
       - name: Checkout source code
-      - uses: actions/checkout@v2.3.2
+        uses: actions/checkout@v2.3.2
 
       - name: Cache Gradle
         uses: actions/cache@v2


### PR DESCRIPTION
#165 

## What happened 👀

There's a `-` too many, which is causing the workflows to fail.

Please check the issue for more information

## Insight 📝

I found the solution from here: https://github.com/einaregilsson/beanstalk-deploy/issues/2#issuecomment-555894644

## Proof Of Work 📹

Checks are all succeeded: https://github.com/nimblehq/android-templates/pull/166/checks