### PR TITLE
[#179] Fix: incorrect Jacoco coverage report after migrating to Kotlin DSL

### DIFF
--- a/RxJavaTemplate/.gitignore
+++ b/RxJavaTemplate/.gitignore
@@ -55,3 +55,6 @@ freeline_project_description.json
 
 # Fastlane
 fastlane/report.xml
+
+# Code coverage
+jacoco.exec

--- a/RxJavaTemplate/app/.gitignore
+++ b/RxJavaTemplate/app/.gitignore
@@ -1,2 +1,1 @@
 /build
-jacoco.exec

--- a/RxJavaTemplate/config/jacoco.gradle.kts
+++ b/RxJavaTemplate/config/jacoco.gradle.kts
@@ -11,12 +11,28 @@ val fileGenerated = setOf(
     "**/*_ViewBinding*.*",
     "**/*Adapter*.*",
     "**/*Test*.*",
-    "android/**/*.*"
+    // Enum
+    "**/*\$Creator*",
+    // Nav Component
+    "**/*_Factory*",
+    "**/*FragmentArgs*",
+    "**/*FragmentDirections*",
+    "**/FragmentNavArgsLazy.kt",
+    "**/*Fragment*navArgs*",
+    "**/*ModuleDeps*.*",
+    "**/*NavGraphDirections*",
+    // Hilt
+    "**/*_HiltComponents*",
+    "**/*_HiltModules*",
+    "**/Hilt_*"
 )
 
 val packagesExcluded = setOf(
-    "**/co/nimblehq/rxjava/di/**",
-    "**/com/bumptech/glide"
+    "**/com/bumptech/glide",
+    "**/dagger/hilt/internal",
+    "**/hilt_aggregated_deps",
+    "**/co/nimblehq/rxjava/databinding/**",
+    "**/co/nimblehq/rxjava/di/**"
 )
 
 val fileFilter = fileGenerated + packagesExcluded

--- a/RxJavaTemplate/config/jacoco.gradle.kts
+++ b/RxJavaTemplate/config/jacoco.gradle.kts
@@ -42,8 +42,10 @@ val classDirectoriesTree = files(
         include(
             "**/app/build/intermediates/javac/stagingDebug/classes/**",
             "**/data/build/intermediates/javac/stagingDebug/classes/**",
+            "**/domain/build/intermediates/javac/stagingDebug/classes/**",
             "**/app/build/tmp/kotlin-classes/stagingDebug/**",
-            "**/data/build/tmp/kotlin-classes/stagingDebug/**"
+            "**/data/build/tmp/kotlin-classes/stagingDebug/**",
+            "**/domain/build/tmp/kotlin-classes/stagingDebug/**"
         )
         exclude(fileFilter)
     }
@@ -52,7 +54,8 @@ val classDirectoriesTree = files(
 val sourceDirectoriesTree = files(
     listOf(
         "${project.rootDir}/app/src/main/java",
-        "${project.rootDir}/data/src/main/java"
+        "${project.rootDir}/data/src/main/java",
+        "${project.rootDir}/domain/src/main/java"
     )
 )
 
@@ -68,7 +71,8 @@ val sourceDirectoriesTree = files(
 val executionDataTree = fileTree(project.rootDir) {
     include(
         "app/jacoco.exec",
-        "common/jacoco.exec"
+        "data/jacoco.exec",
+        "domain/jacoco.exec"
     )
 }
 
@@ -78,7 +82,8 @@ tasks.register<JacocoReport>("jacocoTestReport") {
 
     dependsOn(
         ":app:testStagingDebugUnitTest",
-        ":data:testStagingDebugUnitTest"
+        ":data:testStagingDebugUnitTest",
+        ":domain:testStagingDebugUnitTest"
     )
 
     classDirectories.setFrom(classDirectoriesTree)

--- a/RxJavaTemplate/config/jacoco.gradle.kts
+++ b/RxJavaTemplate/config/jacoco.gradle.kts
@@ -15,9 +15,8 @@ val fileGenerated = setOf(
 )
 
 val packagesExcluded = setOf(
-    "co/nimblehq/di/**",
-    "co/nimblehq/ui/**/di/**",
-    "com/bumptech/glide"
+    "**/co/nimblehq/rxjava/di/**",
+    "**/com/bumptech/glide"
 )
 
 val fileFilter = fileGenerated + packagesExcluded

--- a/RxJavaTemplate/data/.gitignore
+++ b/RxJavaTemplate/data/.gitignore
@@ -1,2 +1,1 @@
 /build
-jacoco.exec

--- a/RxJavaTemplate/domain/build.gradle.kts
+++ b/RxJavaTemplate/domain/build.gradle.kts
@@ -36,6 +36,14 @@ android {
         }
         getByName(BuildType.DEBUG) {
             isMinifyEnabled = false
+            /**
+             * From AGP 4.2.0, Jacoco generates the report incorrectly, and the report is missing
+             * some code coverage from module. On the new version of Gradle, they introduce a new
+             * flag [testCoverageEnabled], we must enable this flag if using Jacoco to capture
+             * coverage and creates a report in the build directory.
+             * Reference: https://developer.android.com/reference/tools/gradle-api/7.1/com/android/build/api/dsl/BuildType#istestcoverageenabled
+             */
+            isTestCoverageEnabled = true
         }
     }
 


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/179

## What happened 👀

After migrating [Jacoco config to Kotlin DSL](https://github.com/nimblehq/android-templates/pull/145), Jacoco is reporting **incorrect** coverage with some redundant packages and classes.

## Insight 📝

- In Kotlin DSL, we need to add `**/` prefix for package excludes.
- There are also some more packages and classes that should be excluded, such as Hilt, Nav Component, Data binding, Kotlin enum, etc.

```
dagger.hilt.internal.aggregatedroot.codegen
dagger.hilt.internal.processedrootsentinel.codegen
hilt_aggregated_deps
```

## Proof Of Work 📹

|  After | Before |
| - | - |
| <img width="521" alt="image" src="https://user-images.githubusercontent.com/16315358/161622990-a58abcce-f765-422a-b1d7-f813330aeb28.png"> | ![image](https://user-images.githubusercontent.com/16315358/161615008-680d9ece-4b33-4d19-99f5-6a501aa8f5df.png) | 
| <img width="529" alt="image" src="https://user-images.githubusercontent.com/16315358/161612666-636fe0c6-367d-4eaa-b99d-1da788468268.png"> | ![image](https://user-images.githubusercontent.com/16315358/161613811-a0a82268-a4e5-4abb-bd60-54e5659c7b27.png) | 
| <img width="590" alt="image" src="https://user-images.githubusercontent.com/16315358/161613012-d9c7ff8c-f383-4a42-acac-210e2f0c7686.png"> | ![image](https://user-images.githubusercontent.com/16315358/161614277-55f63610-1d35-436c-8fe4-240622fc110c.png) | 
| <img width="633" alt="image" src="https://user-images.githubusercontent.com/16315358/161613106-c8e6ea64-81f0-4837-8439-f094813c60bd.png"> | ![image](https://user-images.githubusercontent.com/16315358/161614381-95319d86-3324-47da-83b0-ab5c09066feb.png) | 
| <img width="695" alt="image" src="https://user-images.githubusercontent.com/16315358/161613424-c22d3c90-af15-4ce4-af07-35e378c87af5.png"> | ![image](https://user-images.githubusercontent.com/16315358/161613520-0bf6b76e-a408-4bf1-bc72-7bf643c3551b.png) | 
| <img width="650" alt="image" src="https://user-images.githubusercontent.com/16315358/161614667-57f8dce4-b540-48df-b6da-3463951026fb.png"> | ![image](https://user-images.githubusercontent.com/16315358/161614754-dd133fcc-8a74-4303-af50-0cae05c16bef.png) | 




