### PR TITLE
[#169] Add Jacoco to CoroutineTemplate

### DIFF
--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -37,7 +37,9 @@ jobs:
         working-directory: ./CoroutineTemplate
         run: ./gradlew lint
 
-      # TODO: Update to support test coverage reports from Jacoco for CoroutineTemplate
+      - name: Run unit tests and Jacoco on CoroutineTemplate
+        working-directory: ./CoroutineTemplate
+        run: ./gradlew jacocoTestReport
 
       - name: Set up Ruby
         uses: actions/setup-ruby@v1

--- a/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.github/workflows/run_detekt_and_unit_tests.yml
@@ -36,3 +36,13 @@ jobs:
         with:
           name: DetektReportsCoroutine
           path: CoroutineTemplate/build/reports/detekt/
+
+      - name: Run unit tests and Jacoco on CoroutineTemplate
+        working-directory: ./CoroutineTemplate
+        run: ./gradlew jacocoTestReport
+
+      - name: Archive code coverage reports on CoroutineTemplate
+        uses: actions/upload-artifact@v2
+        with:
+          name: CodeCoverageReportsCoroutine
+          path: CoroutineTemplate/app/build/reports/jacoco/jacocoTestReport/

--- a/CoroutineTemplate/.gitignore
+++ b/CoroutineTemplate/.gitignore
@@ -42,3 +42,6 @@ secret/
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild
+
+# Code coverage
+jacoco.exec

--- a/CoroutineTemplate/README.md
+++ b/CoroutineTemplate/README.md
@@ -3,23 +3,38 @@
 
 ### Setup
 - Clone the project
-- Checkout our main development branch `kotlin`
 - Run the project with Android Studio
 
 ### Linter and static code analysis
 
-1. Check Style:
+- Lint:
 
 ```
-$ ./gradlew checkStyle
+$ ./gradlew lint
 ```
 
-Report is located at: `./app/build/reports/checkstyle/`
+Report is located at: `./app/build/reports/lint/`
 
-2. Detekt
+- Detekt
 
 ```
 $ ./gradlew detekt
 ```
 
-Report is located at: `./build/reports/detekt.html`
+Report is located at: `./build/reports/detekt`
+
+### Testing
+
+- Run unit testing:
+
+```
+$ ./gradlew test
+```
+
+- Run unit testing with coverage:
+
+```
+$ ./gradlew jacocoTestReport
+```
+
+Report is located at: `./app/build/reports/jacoco/`

--- a/CoroutineTemplate/README.md
+++ b/CoroutineTemplate/README.md
@@ -28,7 +28,9 @@ Report is located at: `./build/reports/detekt`
 - Run unit testing:
 
 ```
-$ ./gradlew test
+$ ./gradlew app:testStagingDebugUnitTest
+$ ./gradlew data:testDebugUnitTest
+$ ./gradlew domain:test
 ```
 
 - Run unit testing with coverage:

--- a/CoroutineTemplate/app/build.gradle.kts
+++ b/CoroutineTemplate/app/build.gradle.kts
@@ -7,7 +7,11 @@ plugins {
 
     id("dagger.hilt.android.plugin")
     id("androidx.navigation.safeargs.kotlin")
+
+    jacoco
 }
+
+apply(from = "../config/jacoco.gradle.kts")
 
 val keystoreProperties = rootDir.loadGradleProperties("signing.properties")
 
@@ -44,6 +48,14 @@ android {
             // For quickly testing build with proguard, enable this
             isMinifyEnabled = false
             buildConfigField("String", "BASE_API_URL", "\"https://jsonplaceholder.typicode.com/\"")
+            /**
+             * From AGP 4.2.0, Jacoco generates the report incorrectly, and the report is missing
+             * some code coverage from module. On the new version of Gradle, they introduce a new
+             * flag [testCoverageEnabled], we must enable this flag if using Jacoco to capture
+             * coverage and creates a report in the build directory.
+             * Reference: https://developer.android.com/reference/tools/gradle-api/7.1/com/android/build/api/dsl/BuildType#istestcoverageenabled
+             */
+            isTestCoverageEnabled = true
         }
     }
 
@@ -92,6 +104,10 @@ android {
             isReturnDefaultValues = true
         }
     }
+}
+
+jacoco {
+    toolVersion = "0.8.7"
 }
 
 kapt {

--- a/CoroutineTemplate/app/build.gradle.kts
+++ b/CoroutineTemplate/app/build.gradle.kts
@@ -8,10 +8,8 @@ plugins {
     id("dagger.hilt.android.plugin")
     id("androidx.navigation.safeargs.kotlin")
 
-    jacoco
+    id("plugins.jacoco-report")
 }
-
-apply(from = "../config/jacoco.gradle.kts")
 
 val keystoreProperties = rootDir.loadGradleProperties("signing.properties")
 
@@ -104,10 +102,6 @@ android {
             isReturnDefaultValues = true
         }
     }
-}
-
-jacoco {
-    toolVersion = Versions.JACOCO_VERSION
 }
 
 kapt {

--- a/CoroutineTemplate/app/build.gradle.kts
+++ b/CoroutineTemplate/app/build.gradle.kts
@@ -107,7 +107,7 @@ android {
 }
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = Versions.JACOCO_VERSION
 }
 
 kapt {

--- a/CoroutineTemplate/buildSrc/src/main/java/Versions.kt
+++ b/CoroutineTemplate/buildSrc/src/main/java/Versions.kt
@@ -24,6 +24,7 @@ object Versions {
     const val HILT_VERSION = "2.38.1"
 
     const val JAVAX_INJECT_VERSION = "1"
+    const val JACOCO_VERSION = "0.8.7"
 
     const val KOTLIN_REFLECT_VERSION = "1.5.10"
     const val KOTLIN_VERSION = "1.5.21"

--- a/CoroutineTemplate/buildSrc/src/main/java/plugins/jacoco-report.gradle.kts
+++ b/CoroutineTemplate/buildSrc/src/main/java/plugins/jacoco-report.gradle.kts
@@ -1,4 +1,12 @@
-apply(plugin = "jacoco")
+package plugins
+
+plugins {
+    jacoco
+}
+
+jacoco {
+    toolVersion = Versions.JACOCO_VERSION
+}
 
 val fileGenerated = setOf(
     "**/R.class",

--- a/CoroutineTemplate/config/jacoco.gradle.kts
+++ b/CoroutineTemplate/config/jacoco.gradle.kts
@@ -22,6 +22,7 @@ val fileGenerated = setOf(
     "**/*ModuleDeps*.*",
     "**/*NavGraphDirections*",
     // Hilt
+    "**/*_ComponentTreeDeps*",
     "**/*_HiltComponents*",
     "**/*_HiltModules*",
     "**/Hilt_*"

--- a/CoroutineTemplate/config/jacoco.gradle.kts
+++ b/CoroutineTemplate/config/jacoco.gradle.kts
@@ -43,7 +43,8 @@ val classDirectoriesTree = files(
             "**/app/build/intermediates/javac/stagingDebug/classes/**",
             "**/data/build/intermediates/javac/debug/classes/**",
             "**/app/build/tmp/kotlin-classes/stagingDebug/**",
-            "**/data/build/tmp/kotlin-classes/debug/**"
+            "**/data/build/tmp/kotlin-classes/debug/**",
+            "**/domain/build/classes/kotlin/main/**"
         )
         exclude(fileFilter)
     }
@@ -52,7 +53,8 @@ val classDirectoriesTree = files(
 val sourceDirectoriesTree = files(
     listOf(
         "${project.rootDir}/app/src/main/java",
-        "${project.rootDir}/data/src/main/java"
+        "${project.rootDir}/data/src/main/java",
+        "${project.rootDir}/domain/src/main/java"
     )
 )
 
@@ -68,7 +70,8 @@ val sourceDirectoriesTree = files(
 val executionDataTree = fileTree(project.rootDir) {
     include(
         "app/jacoco.exec",
-        "data/jacoco.exec"
+        "data/jacoco.exec",
+        "domain/build/jacoco/test.exec"
     )
 }
 
@@ -78,7 +81,8 @@ tasks.register<JacocoReport>("jacocoTestReport") {
 
     dependsOn(
         ":app:testStagingDebugUnitTest",
-        ":data:testDebugUnitTest"
+        ":data:testDebugUnitTest",
+        ":domain:test"
     )
 
     classDirectories.setFrom(classDirectoriesTree)

--- a/CoroutineTemplate/config/jacoco.gradle.kts
+++ b/CoroutineTemplate/config/jacoco.gradle.kts
@@ -1,0 +1,124 @@
+apply(plugin = "jacoco")
+
+val fileGenerated = setOf(
+    "**/R.class",
+    "**/R\$*.class",
+    "**/*\$ViewBinder*.*",
+    "**/*\$InjectAdapter*.*",
+    "**/*Injector*.*",
+    "**/BuildConfig.*",
+    "**/Manifest*.*",
+    "**/*_ViewBinding*.*",
+    "**/*Adapter*.*",
+    "**/*Test*.*",
+    // Enum
+    "**/*\$Creator*",
+    // Nav Component
+    "**/*_Factory*",
+    "**/*FragmentArgs*",
+    "**/*FragmentDirections*",
+    "**/FragmentNavArgsLazy.kt",
+    "**/*Fragment*navArgs*",
+    "**/*ModuleDeps*.*",
+    "**/*NavGraphDirections*",
+    // Hilt
+    "**/*_HiltComponents*",
+    "**/*_HiltModules*",
+    "**/Hilt_*"
+)
+
+val packagesExcluded = setOf(
+    "**/com/bumptech/glide",
+    "**/dagger/hilt/internal",
+    "**/hilt_aggregated_deps",
+    "**/co/nimblehq/coroutine/databinding/**",
+    "**/co/nimblehq/coroutine/di/**"
+)
+
+val fileFilter = fileGenerated + packagesExcluded
+
+val classDirectoriesTree = files(
+    fileTree(project.rootDir) {
+        include(
+            "**/app/build/intermediates/javac/stagingDebug/classes/**",
+            "**/app/build/tmp/kotlin-classes/stagingDebug/**"
+        )
+        exclude(fileFilter)
+    }
+)
+
+val sourceDirectoriesTree = files(
+    listOf(
+        "${project.rootDir}/app/src/main/java"
+    )
+)
+
+/**
+ * Once enabled [testCoverageEnabled], Jacoco will capture the coverage and store them in
+ * [${project.module}/jacoco.exec]. We need to add all [jacoco.exec] to here.
+ * [${project.module}/build/jacoco/testFlavorDebugTest.exec] won't have the result anymore, so we
+ * can safety get rid of them.
+ * Reference: https://stackoverflow.com/a/67626100/5187859
+ * Issue tracker 1: https://issuetracker.google.com/issues/171125857#comment20
+ * Issue tracker 2: https://issuetracker.google.com/issues/195860510
+ */
+val executionDataTree = fileTree(project.rootDir) {
+    include(
+        "app/jacoco.exec"
+    )
+}
+
+tasks.register<JacocoReport>("jacocoTestReport") {
+    group = "Reporting"
+    description = "Generate Jacoco coverage reports for Debug build"
+
+    dependsOn(
+        ":app:testStagingDebugUnitTest"
+    )
+
+    classDirectories.setFrom(classDirectoriesTree)
+    sourceDirectories.setFrom(sourceDirectoriesTree)
+    executionData.setFrom(executionDataTree)
+
+    reports {
+        xml.isEnabled = true
+        html.isEnabled = true
+        csv.isEnabled = false
+    }
+}
+
+tasks.withType<Test> {
+    configure<JacocoTaskExtension> {
+        isIncludeNoLocationClasses = true
+        /*
+         * From AGP 4.2, JDK 11 is now bundled, but Jacoco is running on JDK 8. It causes the
+         * build failed because of the missing of some classes that do not exist on JDK 8 but
+         * JDK 11. We need to exclude that classes temporarily until Jacoco supports running
+         * on JDK 11.
+         * Android Gradle Plugin 4.2.0 release note: https://developer.android.com/studio/releases#4.2-bundled-jdk-11
+         * Reference: https://stackoverflow.com/a/68739364/5187859
+         */
+        excludes = listOf("jdk.internal.*")
+    }
+}
+
+/**
+ * Workaround to bypass "Caused by: java.lang.IllegalStateException:
+ * Cannot process instrumented class...
+ * Please supply original non-instrumented classes." issue.
+ *
+ * Application projects that depend on variants of libraries that have test coverage enabled will
+ * still not work as app code should be instrumented on the fly, while library code should not be.
+ * https://issuetracker.google.com/issues/171125857#comment26
+ */
+tasks.withType<Test>().configureEach {
+    configure<JacocoTaskExtension> {
+        includes = listOf("com.application.*") // include only application classes
+    }
+}
+
+tasks.withType<Test> {
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}

--- a/CoroutineTemplate/config/jacoco.gradle.kts
+++ b/CoroutineTemplate/config/jacoco.gradle.kts
@@ -41,7 +41,9 @@ val classDirectoriesTree = files(
     fileTree(project.rootDir) {
         include(
             "**/app/build/intermediates/javac/stagingDebug/classes/**",
-            "**/app/build/tmp/kotlin-classes/stagingDebug/**"
+            "**/data/build/intermediates/javac/debug/classes/**",
+            "**/app/build/tmp/kotlin-classes/stagingDebug/**",
+            "**/data/build/tmp/kotlin-classes/debug/**"
         )
         exclude(fileFilter)
     }
@@ -49,7 +51,8 @@ val classDirectoriesTree = files(
 
 val sourceDirectoriesTree = files(
     listOf(
-        "${project.rootDir}/app/src/main/java"
+        "${project.rootDir}/app/src/main/java",
+        "${project.rootDir}/data/src/main/java"
     )
 )
 
@@ -64,7 +67,8 @@ val sourceDirectoriesTree = files(
  */
 val executionDataTree = fileTree(project.rootDir) {
     include(
-        "app/jacoco.exec"
+        "app/jacoco.exec",
+        "data/jacoco.exec"
     )
 }
 
@@ -73,7 +77,8 @@ tasks.register<JacocoReport>("jacocoTestReport") {
     description = "Generate Jacoco coverage reports for Debug build"
 
     dependsOn(
-        ":app:testStagingDebugUnitTest"
+        ":app:testStagingDebugUnitTest",
+        ":data:testDebugUnitTest"
     )
 
     classDirectories.setFrom(classDirectoriesTree)

--- a/CoroutineTemplate/data/build.gradle.kts
+++ b/CoroutineTemplate/data/build.gradle.kts
@@ -2,10 +2,8 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
 
-    jacoco
+    id("plugins.jacoco-report")
 }
-
-apply(from = "../config/jacoco.gradle.kts")
 
 android {
     compileSdk = Versions.ANDROID_COMPILE_SDK_VERSION
@@ -50,10 +48,6 @@ android {
         xmlReport = true
         xmlOutput = file("build/reports/lint/lint-result.xml")
     }
-}
-
-jacoco {
-    toolVersion = Versions.JACOCO_VERSION
 }
 
 dependencies {

--- a/CoroutineTemplate/data/build.gradle.kts
+++ b/CoroutineTemplate/data/build.gradle.kts
@@ -1,7 +1,11 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
+
+    jacoco
 }
+
+apply(from = "../config/jacoco.gradle.kts")
 
 android {
     compileSdk = Versions.ANDROID_COMPILE_SDK_VERSION
@@ -20,6 +24,16 @@ android {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
         }
+        getByName(BuildType.DEBUG) {
+            /**
+             * From AGP 4.2.0, Jacoco generates the report incorrectly, and the report is missing
+             * some code coverage from module. On the new version of Gradle, they introduce a new
+             * flag [testCoverageEnabled], we must enable this flag if using Jacoco to capture
+             * coverage and creates a report in the build directory.
+             * Reference: https://developer.android.com/reference/tools/gradle-api/7.1/com/android/build/api/dsl/BuildType#istestcoverageenabled
+             */
+            isTestCoverageEnabled = true
+        }
     }
 
     compileOptions {
@@ -36,6 +50,10 @@ android {
         xmlReport = true
         xmlOutput = file("build/reports/lint/lint-result.xml")
     }
+}
+
+jacoco {
+    toolVersion = "0.8.7"
 }
 
 dependencies {

--- a/CoroutineTemplate/data/build.gradle.kts
+++ b/CoroutineTemplate/data/build.gradle.kts
@@ -74,4 +74,10 @@ dependencies {
 
     api("com.squareup.okhttp3:okhttp:${Versions.OKHTTP_VERSION}")
     api("com.squareup.okhttp3:logging-interceptor:${Versions.OKHTTP_VERSION}")
+
+    // Testing
+    testImplementation("junit:junit:${Versions.TEST_JUNIT_VERSION}")
+    testImplementation("io.mockk:mockk:${Versions.TEST_MOCKK_VERSION}")
+    testImplementation("io.kotest:kotest-assertions-core:${Versions.TEST_KOTEST_VERSION}")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.KOTLINX_COROUTINES_VERSION}")
 }

--- a/CoroutineTemplate/data/build.gradle.kts
+++ b/CoroutineTemplate/data/build.gradle.kts
@@ -53,7 +53,7 @@ android {
 }
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = Versions.JACOCO_VERSION
 }
 
 dependencies {

--- a/CoroutineTemplate/data/src/test/java/co/nimblehq/coroutine/data/repositoryimpl/UserRepositoryTest.kt
+++ b/CoroutineTemplate/data/src/test/java/co/nimblehq/coroutine/data/repositoryimpl/UserRepositoryTest.kt
@@ -1,0 +1,53 @@
+package co.nimblehq.coroutine.data.repositoryimpl
+
+import co.nimblehq.coroutine.data.response.UserResponse
+import co.nimblehq.coroutine.data.response.toUsers
+import co.nimblehq.coroutine.data.service.ApiService
+import co.nimblehq.coroutine.domain.repository.UserRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class UserRepositoryTest {
+
+    private lateinit var mockService: ApiService
+    private lateinit var repository: UserRepository
+
+    private val userResponse = UserResponse(
+        id = 1,
+        name = "name",
+        username = "username",
+        email = "email",
+        addressResponse = null,
+        phone = null,
+        website = null
+    )
+
+    @Before
+    fun setup() {
+        mockService = mockk()
+        repository = UserRepositoryImpl(mockService)
+    }
+
+    @Test
+    fun `When calling getUsers request successfully, it returns success response`() = runBlockingTest {
+        coEvery { mockService.getUsers() } returns listOf(userResponse)
+
+        repository.getUsers() shouldBe listOf(userResponse).toUsers()
+    }
+
+    @Test
+    fun `When calling getUsers request failed, it returns wrapped error`() = runBlockingTest {
+        coEvery { mockService.getUsers() } throws Throwable()
+
+        shouldThrow<Throwable> {
+            repository.getUsers()
+        }
+    }
+}

--- a/CoroutineTemplate/domain/build.gradle.kts
+++ b/CoroutineTemplate/domain/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     id("java-library")
     id("kotlin")
+
+    jacoco
 }
 
 java {
@@ -8,6 +10,16 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+jacoco {
+    toolVersion = "0.8.7"
+}
+
 dependencies {
     implementation("javax.inject:javax.inject:${Versions.JAVAX_INJECT_VERSION}")
+
+    // Testing
+    testImplementation("junit:junit:${Versions.TEST_JUNIT_VERSION}")
+    testImplementation("io.mockk:mockk:${Versions.TEST_MOCKK_VERSION}")
+    testImplementation("io.kotest:kotest-assertions-core:${Versions.TEST_KOTEST_VERSION}")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.KOTLINX_COROUTINES_VERSION}")
 }

--- a/CoroutineTemplate/domain/build.gradle.kts
+++ b/CoroutineTemplate/domain/build.gradle.kts
@@ -10,10 +10,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-jacoco {
-    toolVersion = "0.8.7"
-}
-
 dependencies {
     implementation("javax.inject:javax.inject:${Versions.JAVAX_INJECT_VERSION}")
 

--- a/CoroutineTemplate/domain/src/test/java/co/nimblehq/coroutine/domain/usecase/GetUsersUseCaseTest.kt
+++ b/CoroutineTemplate/domain/src/test/java/co/nimblehq/coroutine/domain/usecase/GetUsersUseCaseTest.kt
@@ -1,0 +1,54 @@
+package co.nimblehq.coroutine.domain.usecase
+
+import co.nimblehq.coroutine.domain.model.User
+import co.nimblehq.coroutine.domain.repository.UserRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class GetUsersUseCaseTest {
+
+    private lateinit var mockRepository: UserRepository
+    private lateinit var usecase: GetUsersUseCase
+
+    private val user = User(
+        id = 1,
+        name = "name",
+        username = "username",
+        email = "email",
+        address = null,
+        phone = "",
+        website = ""
+    )
+
+    @Before
+    fun setup() {
+        mockRepository = mockk()
+        usecase = GetUsersUseCase(mockRepository)
+    }
+
+    @Test
+    fun `When calling request successfully, it returns success response`() = runBlockingTest {
+        val expected = listOf(user)
+        coEvery { mockRepository.getUsers() } returns expected
+
+        usecase.execute().run {
+            (this as UseCaseResult.Success).data shouldBe expected
+        }
+    }
+
+    @Test
+    fun `When calling request failed, it returns wrapped error`() = runBlockingTest {
+        val expected = Exception()
+        coEvery { mockRepository.getUsers() } throws expected
+
+        usecase.execute().run {
+            (this as UseCaseResult.Error).exception shouldBe expected
+        }
+    }
+}

--- a/Dangerfile
+++ b/Dangerfile
@@ -29,4 +29,11 @@ Dir[lint_dir].each do |file_name|
   android_lint.lint(inline_mode: true)
 end
   
-# TODO: Update to support test coverage report from Jacoco for Coroutine Template
+# Show Danger test coverage report from Jacoco for CoroutineTemplate
+jacoco_dir = "CoroutineTemplate/**/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
+markdown "## CoroutineTemplate Jacoco report:"
+Dir[jacoco_dir].each do |file_name|
+  # Report coverage of modified files, warn if total project coverage is under 80%
+  # or if any modified file's coverage is under 95%
+  shroud.report file_name, 80, 95, false
+end


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/169

## What happened 👀

Jacoco is currently not supported for `CoroutineTemplate`, however, it is working correctly for `RxJavaTemplate`

In `.github/workflows/review_pull_request.yml` there's a pending TODO

Let's make sure Jacoco can run the tests and generate a report in the CI successfully.

## Insight 📝

- From what we achieved in this PR https://github.com/nimblehq/android-templates/pull/137, we can set up the Jacoco report for `app` module easily, however, one caution is:
  - We need to force to use Jacoco version `0.8.7` to bypass this issue https://youtrack.jetbrains.com/issue/KT-44757 on `Kotlin 1.5` 🤓 
- Add Jacoco report to `data` module. This is an Android library module without app flavor so there is a change in `classDirectoriesTree` and `dependsOn` configurations.
- Add Jacoco report to `domain` module. This is a `java-library` module (not an Android module) so:
  - `classDirectoriesTree` is `**/domain/build/classes/kotlin/main/**`
  - `executionDataTree` is `domain/build/jacoco/test.exec`, no `jacoco.exec` in module folder.
  - `dependsOn` is `:domain:test`
- The rest of tasks is easy to support test coverage reports in CI for `CoroutineTemplate` 💪 

## Proof Of Work 📹

- Jacoco report for all available project modules ✅ 

<img width="747" alt="image" src="https://user-images.githubusercontent.com/16315358/162058171-171b5f76-165f-4753-9b11-274d047619eb.png">

- The code coverage report by Danger is generated properly ✅ 
