### PR TITLE
[#200] Initialize new project directory and copy files recursively

### DIFF
--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -1,14 +1,27 @@
+import java.io.File
+
 object NewProject {
 
+    private const val ARGUMENT_DELIMITER = "="
     private const val KEY_APP_NAME = "app-name"
     private const val KEY_PACKAGE_NAME = "package-name"
-    private const val ARGUMENT_DELIMITER = "="
+    private const val TEMPLATE_FOLDER_NAME = "CoroutineTemplate"
 
     private var appName = ""
+    private val appNameWithoutSpace: String
+        get() = appName.replace(" ", "")
     private var packageName = ""
 
     fun generate(args: Array<String>) {
         handleArguments(args)
+        initializeNewProjectFolder()
+    }
+
+    private fun initializeNewProjectFolder() {
+        showMessage("=> 🐢 Initializing new project...")
+        copyFiles(fromPath = TEMPLATE_FOLDER_NAME, toPath = appNameWithoutSpace)
+        // Set gradlew file as executable, because copying files from one folder to another doesn't copy file permissions correctly (= read, write & execute).
+        File("../$appNameWithoutSpace/gradlew")?.setExecutable(true)
     }
 
     private fun handleArguments(args: Array<String>) {
@@ -18,6 +31,19 @@ object NewProject {
                 KEY_APP_NAME -> appName = value
                 KEY_PACKAGE_NAME -> packageName = value
             }
+        }
+    }
+
+    private fun showMessage(message: String) {
+        println("\n${message}\n")
+    }
+
+    private fun copyFiles(fromPath: String, toPath: String) {
+        val targetFolder = File("../$toPath")
+        val sourceFolder = File("../$fromPath")
+        sourceFolder.copyRecursively(targetFolder, true) { file, exception ->
+            showMessage(exception?.message ?: "Error copying files")
+            return@copyRecursively OnErrorAction.TERMINATE
         }
     }
 }


### PR DESCRIPTION
[#200](https://github.com/nimblehq/android-templates/issues/200)

## What happened 👀

- Show "=> 🐢 Initializing new project..." in the logs
- Initialize project folder by copying CoroutineTemplate recursively
- Rename project folder according to trimmed app-name
   - If app-name="My Project", then the project folder must be named "MyProject"

## Insight 📝

- Create new folder for the project and name the project without space
- Copy files to new folder recursively
- Enable `gradlew` to be `executable`

## Proof Of Work 📹


https://user-images.githubusercontent.com/32578035/167353504-8e7f22e0-24b2-4a18-a9f3-8f9c5e9dd10e.mov


