### PR TITLE
[#206] Rename package names within files

### DIFF
--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -6,6 +6,7 @@ object NewProject {
     private const val KEY_APP_NAME = "app-name"
     private const val KEY_PACKAGE_NAME = "package-name"
     private const val TEMPLATE_FOLDER_NAME = "CoroutineTemplate"
+    private const val TEMPLATE_PACKAGE_NAME = "co.nimblehq.coroutine"
 
     private var appName = ""
     private val appNameWithoutSpace: String
@@ -20,6 +21,7 @@ object NewProject {
         handleArguments(args)
         initializeNewProjectFolder()
         cleanNewProjectFolder()
+        renamePackageNameWithinFiles()
     }
 
     private fun initializeNewProjectFolder() {
@@ -65,6 +67,27 @@ object NewProject {
     private fun executeCommand(command: String) {
         val process = Runtime.getRuntime().exec(command)
         process.inputStream.reader().forEachLine { println(it) }
+    }
+
+    private fun renamePackageNameWithinFiles() {
+        showMessage("=> 🔎 Renaming package name within files...")
+        File(projectPath)
+            ?.walk()
+            .filter { it.isFile }
+            .forEach { filePath ->
+                rename(
+                    sourcePath = filePath.toString(),
+                    oldValue = TEMPLATE_PACKAGE_NAME,
+                    newValue = packageName
+                )
+            }
+    }
+
+    private fun rename(sourcePath: String, oldValue: String, newValue: String) {
+        val sourceFile = File(sourcePath)
+        var sourceText = sourceFile.readText()
+        sourceText = sourceText.replace(oldValue, newValue)
+        sourceFile.writeText(sourceText)
     }
 }
 


### PR DESCRIPTION
[#206](https://github.com/nimblehq/android-templates/issues/206)

## What happened 👀

- Show "=> 🔎 Renaming package name within files..." in the log
- Rename package name and imports according to package-name, including AndroidManifest.xml

## Insight 📝

- Read each file contents and replace `old package name` with `new package name`

## Proof Of Work 📹
<img width="682" alt="Screen Shot 2022-05-13 at 10 58 22 AM" src="https://user-images.githubusercontent.com/32578035/168208459-6f770c54-e27e-4eab-8692-f5a7e40ae20f.png">

![Screen Shot 2022-05-13 at 10 59 17 AM](https://user-images.githubusercontent.com/32578035/168208541-1007bc34-d56c-42b1-abdb-ef05209b5688.png)

![Screen Shot 2022-05-13 at 10 59 52 AM](https://user-images.githubusercontent.com/32578035/168208610-7e4071ba-4914-4ebe-9cb4-d3dca17d5c21.png)

