### PR TITLE
[#206] Fix corrupted `debug.keystore` after renaming

### DIFF
--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -73,7 +73,7 @@ object NewProject {
         showMessage("=> 🔎 Renaming package name within files...")
         File(projectPath)
             ?.walk()
-            .filter { it.isFile }
+            .filter { it.isFile && it.name != "debug.keystore" }
             .forEach { filePath ->
                 rename(
                     sourcePath = filePath.toString(),


### PR DESCRIPTION
#206 

## What happened 👀

After renaming the package name within files, the `debug.keystore` got corrupted.

So the generated project was no longer buildable:

![Screen Shot 2565-05-18 at 12 50 42](https://user-images.githubusercontent.com/18277915/168966604-ee715870-fe18-4568-be1b-0dae2c96bdf8.png)

My guess is that `debug.keystore` contains the package name of `CoroutineTemplate` 💭 

**Solution**? Skip `debug.keystore` when renaming the package name within files

## Proof Of Work 📹

The generated project is buildable again:

https://user-images.githubusercontent.com/18277915/168966107-1223c392-8e45-4747-9d9d-26f999d99d54.mov
