### PR TITLE
[#208] Rename application class

### DIFF
--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -6,6 +6,7 @@ object NewProject {
     private const val DOT_SEPARATOR = "."
     private const val KEY_APP_NAME = "app-name"
     private const val KEY_PACKAGE_NAME = "package-name"
+    private const val TEMPLATE_APPLICATION_CLASS_NAME = "CoroutineTemplateApplication"
     private const val TEMPLATE_FOLDER_NAME = "CoroutineTemplate"
     private const val TEMPLATE_PACKAGE_NAME = "co.nimblehq.coroutine"
 
@@ -14,6 +15,8 @@ object NewProject {
     private var appName = ""
     private val appNameWithoutSpace: String
         get() = appName.replace(" ", "")
+    private val applicationClassName: String
+        get() = "${appNameWithoutSpace}Application"
     private val fileSeparator = File.separator
     private var packageName = ""
     private val projectPath: String
@@ -27,6 +30,7 @@ object NewProject {
         cleanNewProjectFolder()
         renamePackageNameFolders()
         renamePackageNameWithinFiles()
+        renameApplicationClass()
         buildProjectAndRunTests()
     }
 
@@ -99,6 +103,32 @@ object NewProject {
                     sourcePath = filePath.toString(),
                     oldValue = TEMPLATE_PACKAGE_NAME,
                     newValue = packageName
+                )
+            }
+    }
+
+    private fun renameApplicationClass() {
+        showMessage("=> 🔎 Renaming application class...")
+        File(projectPath)
+            ?.walk()
+            .find { it.name == "$TEMPLATE_APPLICATION_CLASS_NAME.kt" }
+            ?.let { templateApplicationFile ->
+                val newApplicationPath = templateApplicationFile.absolutePath.replaceAfterLast(
+                    delimiter = fileSeparator,
+                    replacement = "$applicationClassName.kt"
+                )
+                val newApplicationFile = File(newApplicationPath)
+                templateApplicationFile.renameTo(newApplicationFile)
+            }
+
+        File(projectPath)
+            ?.walk()
+            .filter { it.name.endsWith(".kt") || it.name.endsWith(".xml") }
+            .forEach { file ->
+                rename(
+                    sourcePath = file.absolutePath,
+                    oldValue = TEMPLATE_APPLICATION_CLASS_NAME,
+                    newValue = applicationClassName
                 )
             }
     }

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -111,25 +111,21 @@ object NewProject {
         showMessage("=> 🔎 Renaming application class...")
         File(projectPath)
             ?.walk()
-            .find { it.name == "$TEMPLATE_APPLICATION_CLASS_NAME.kt" }
-            ?.let { templateApplicationFile ->
-                val newApplicationPath = templateApplicationFile.absolutePath.replaceAfterLast(
-                    delimiter = fileSeparator,
-                    replacement = "$applicationClassName.kt"
-                )
-                val newApplicationFile = File(newApplicationPath)
-                templateApplicationFile.renameTo(newApplicationFile)
-            }
-
-        File(projectPath)
-            ?.walk()
-            .filter { it.name.endsWith(".kt") || it.name.endsWith(".xml") }
+            .filter { it.name == "$TEMPLATE_APPLICATION_CLASS_NAME.kt" || it.name == "AndroidManifest.xml" }
             .forEach { file ->
                 rename(
                     sourcePath = file.absolutePath,
                     oldValue = TEMPLATE_APPLICATION_CLASS_NAME,
                     newValue = applicationClassName
                 )
+                if (file.name == "$TEMPLATE_APPLICATION_CLASS_NAME.kt") {
+                    val newApplicationPath = file.absolutePath.replaceAfterLast(
+                        delimiter = fileSeparator,
+                        replacement = "$applicationClassName.kt"
+                    )
+                    val newApplicationFile = File(newApplicationPath)
+                    file.renameTo(newApplicationFile)
+                }
             }
     }
 


### PR DESCRIPTION
#208 

## What happened 👀

Rename application class according to `app-name` argument, there are two processes:
1. Rename application class file (Ex: `CoroutineTemplateApplication` to `MyProjectApplication`)
2. Rename application class in `AndroidManifest.xml`

## Proof Of Work 📹

https://user-images.githubusercontent.com/18277915/169508816-15042a0c-6553-489f-b70c-b262cd2323b0.mov
