### PR TITLE
[#233] Enable `isMinifyEnabled` for `data`

### DIFF
--- a/CoroutineTemplate/data/build.gradle.kts
+++ b/CoroutineTemplate/data/build.gradle.kts
@@ -19,11 +19,14 @@ android {
 
     buildTypes {
         getByName(BuildType.RELEASE) {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            )
         }
 
         getByName(BuildType.DEBUG) {
+            isMinifyEnabled = false
             /**
              * From AGP 4.2.0, Jacoco generates the report incorrectly, and the report is missing
              * some code coverage from module. On the new version of Gradle, they introduce a new


### PR DESCRIPTION
#233 

## What happened 👀

Enable `isMinifyEnabled` for `data` in CoroutineTemplate (for release variant)

## Proof Of Work 📹

App is buildable in release variant (after manually adding `release.keystore`):

https://user-images.githubusercontent.com/18277915/173030844-3219dbc3-06ce-4446-ab6f-77acf21d9072.mov