### PR TITLE
[#100] Add new workflow to generate release note and version tag automatically

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -4,11 +4,11 @@ tag-template: '$RESOLVED_VERSION'
 
 categories:
   - title: 'Features'
-    label: 'feature'
+    label: 'type : feature'
   - title: 'Chores'
-    label: 'chore'
+    label: 'type : chore'
   - title: 'Bugs'
-    label: 'bug'
+    label: 'type : bug'
 
 change-template: '- $TITLE'
 

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -3,11 +3,11 @@ name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 
 categories:
-  - title: 'Features'
+  - title: '⭐ Features'
     label: 'type : feature'
-  - title: 'Chores'
+  - title: '🧹 Chores'
     label: 'type : chore'
-  - title: 'Bugs'
+  - title: '🐞 Bugs'
     label: 'type : bug'
 
 change-template: '- $TITLE'

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,16 @@
+name-template: '$RESOLVED_VERSION'
+
+tag-template: '$RESOLVED_VERSION'
+
+categories:
+  - title: 'Features'
+    label: 'feature'
+  - title: 'Chores'
+    label: 'chore'
+  - title: 'Bugs'
+    label: 'bug'
+
+change-template: '- $TITLE'
+
+template: |
+  $CHANGES

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -1,4 +1,4 @@
-name: Draft a new release
+name: Draft new release
 
 on:
   push:
@@ -9,13 +9,15 @@ permissions:
   contents: read
 
 jobs:
-  update_release_draft:
+  draft_new_release:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Install Kscript
         run: |
           curl -s "https://get.sdkman.io" | bash
@@ -23,12 +25,14 @@ jobs:
           sdk install kotlin 1.6.21
           sdk install kscript 4.0.3
           echo $PATH >> $GITHUB_PATH
+
       - name: Set version
         working-directory: scripts
         run: |
           COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
           VERSION=$(kscript get_version.kts "$COMMIT_MESSAGE")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Draft release
         uses: release-drafter/release-drafter@v5
         with:

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -26,7 +26,7 @@ jobs:
           sdk install kscript 4.0.3
           echo $PATH >> $GITHUB_PATH
 
-      - name: Set version
+      - name: Get version from the latest commit message
         working-directory: scripts
         run: |
           COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
@@ -35,8 +35,8 @@ jobs:
 
       - name: Draft release
         uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           config-name: release-drafter-config.yml
           version: ${{ env.VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: Create Draft Release
+name: Draft a new release
 
 on:
   push:
@@ -11,15 +11,28 @@ permissions:
 jobs:
   update_release_draft:
     permissions:
-      contents: write  # for release-drafter/release-drafter to create a github release
-      pull-requests: write  # for release-drafter/release-drafter to add label to PR
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      # TODO: determine the next version before the following step and pass it as an input.
-      - uses: release-drafter/release-drafter@v5
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install Kscript
+        run: |
+          curl -s "https://get.sdkman.io" | bash
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          sdk install kotlin 1.6.21
+          sdk install kscript 4.0.3
+          echo $PATH >> $GITHUB_PATH
+      - name: Set version
+        working-directory: scripts
+        run: |
+          COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
+          VERSION=$(kscript get_version.kts "$COMMIT_MESSAGE")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Draft release
+        uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter-config.yml
-          disable-autolabeler: true
-          # version: here goes the next version
+          version: ${{ env.VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Create Draft Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write  # for release-drafter/release-drafter to create a github release
+      pull-requests: write  # for release-drafter/release-drafter to add label to PR
+    runs-on: ubuntu-latest
+    steps:
+      # TODO: determine the next version before the following step and pass it as an input.
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-config.yml
+          disable-autolabeler: true
+          # version: here goes the next version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/get_version.kts
+++ b/scripts/get_version.kts
@@ -1,6 +1,6 @@
 object GetVersion {
 
-    private const val PATTERN_VERSION = "[0-9]+.[0-9]+.[0-9]+"
+    private const val PATTERN_VERSION = "[0-9]+[.][0-9]+[.][0-9]+"
 
     fun search(commitMessage: String): String? {
         return PATTERN_VERSION

--- a/scripts/get_version.kts
+++ b/scripts/get_version.kts
@@ -1,0 +1,17 @@
+import java.io.File
+
+object GetVersion {
+
+    private const val PATTERN_VERSION = "[0-9].[0-9].[0-9]"
+
+    fun search(commitMessage: String): String? {
+        return PATTERN_VERSION
+            .toRegex()
+            .find(commitMessage)
+            ?.value
+    }
+}
+
+val version = GetVersion.search(commitMessage = args.first())
+
+println(version)

--- a/scripts/get_version.kts
+++ b/scripts/get_version.kts
@@ -2,7 +2,7 @@ import java.io.File
 
 object GetVersion {
 
-    private const val PATTERN_VERSION = "[0-9].[0-9].[0-9]"
+    private const val PATTERN_VERSION = "[0-9]+.[0-9]+.[0-9]+"
 
     fun search(commitMessage: String): String? {
         return PATTERN_VERSION

--- a/scripts/get_version.kts
+++ b/scripts/get_version.kts
@@ -1,5 +1,3 @@
-import java.io.File
-
 object GetVersion {
 
     private const val PATTERN_VERSION = "[0-9]+.[0-9]+.[0-9]+"


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/100

## What happened 👀

Add a workflow to automatically generate a release note and tag when pushing changes to `main`.

## Insight 📝

- Added `release-drafter.yml` to be triggered when pushing changes to `main`.
- Used [release-drafter/release-drafter](https://github.com/release-drafter/release-drafter) action to generate a draft release. The content would be the same as our current format. Please suggest emojis if you want them in the content.
> Note: the config file _must_ be on the default branch, i.e, `develop` in our case.
- Added `get_version.kts` to get the version from the commit message passed as an argument. Special thanks to @Tuubz for helping with KScript.

## Proof Of Work 📹

![image](https://user-images.githubusercontent.com/8093908/176353099-33946dde-0604-4ebb-800a-b438b7fab9a7.png)


Closes #100 