### PR TITLE
[#163] Updrade gradle to version 7+

### DIFF
--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Checkout source code
         uses: actions/checkout@v2.3.2

--- a/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.github/workflows/run_detekt_and_unit_tests.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Checkout source code
         uses: actions/checkout@v2.3.2

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Checkout source code
         uses: actions/checkout@v2.3.2

--- a/CoroutineTemplate/app/build.gradle.kts
+++ b/CoroutineTemplate/app/build.gradle.kts
@@ -80,12 +80,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     composeOptions {
@@ -98,7 +98,7 @@ android {
         compose = true
     }
 
-    lintOptions {
+    lint {
         isCheckDependencies = true
         xmlReport = true
         xmlOutput = file("build/reports/lint/lint-result.xml")

--- a/CoroutineTemplate/build.gradle.kts
+++ b/CoroutineTemplate/build.gradle.kts
@@ -31,7 +31,7 @@ tasks.register("clean", Delete::class) {
 
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
     // Target version of the generated JVM bytecode. It is used for type resolution.
-    jvmTarget = JavaVersion.VERSION_1_8.toString()
+    jvmTarget = JavaVersion.VERSION_11.toString()
 }
 
 detekt {

--- a/CoroutineTemplate/buildSrc/src/main/java/Versions.kt
+++ b/CoroutineTemplate/buildSrc/src/main/java/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val BUILD_GRADLE_VERSION = "4.2.1"
+    const val BUILD_GRADLE_VERSION = "7.0.2"
 
     const val ANDROID_COMPILE_SDK_VERSION = 30
     const val ANDROID_MIN_SDK_VERSION = 23

--- a/CoroutineTemplate/data/build.gradle.kts
+++ b/CoroutineTemplate/data/build.gradle.kts
@@ -10,8 +10,6 @@ android {
     defaultConfig {
         minSdk = Versions.ANDROID_MIN_SDK_VERSION
         targetSdk = Versions.ANDROID_TARGET_SDK_VERSION
-        versionCode = Versions.ANDROID_VERSION_CODE
-        versionName = Versions.ANDROID_VERSION_NAME
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
@@ -39,15 +37,15 @@ android {
     }
 
     compileOptions {
-        targetCompatibility = JavaVersion.VERSION_1_8
-        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
-    lintOptions {
+    lint {
         isCheckDependencies = true
         xmlReport = true
         xmlOutput = file("build/reports/lint/lint-result.xml")

--- a/CoroutineTemplate/gradle/wrapper/gradle-wrapper.properties
+++ b/CoroutineTemplate/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip


### PR DESCRIPTION
#163
#182

## What happened 👀

- Change the Gradle version as following:

   - Android Gradle Plugin version: 4.2.1 > 7.1.2 or higher
   - Gradle version: 6.7.1 > 7.4.1 or higher


## Insight 📝

To upgrade GDP to `7+`, we need to upgrade the `java` version from `1.8` to `11`, and Once we upgrade `GDP,` then the issue [#182] has been solved.

Noted: After upgrading GDP to `7+`, There are some `options` extension was deprecated in gradle file e.g. `lintOptions`, `composeOptions` etc. for `lintOptions` we can use just `lint` but for the other, we can consider updating it later on another ticket.

## Proof Of Work 📹 

App can run normally.

<details>
   <summary>Lint have no exceptions.</summary>
   
   ```
   Run ./gradlew lint
> Task :buildSrc:generateExternalPluginSpecBuilders UP-TO-DATE
> Task :buildSrc:extractPrecompiledScriptPluginPlugins UP-TO-DATE
> Task :buildSrc:compilePluginsBlocks UP-TO-DATE
> Task :buildSrc:generatePrecompiledScriptPluginAccessors UP-TO-DATE
> Task :buildSrc:generateScriptPluginAdapters UP-TO-DATE
> Task :buildSrc:compileKotlin UP-TO-DATE
> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources UP-TO-DATE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:inspectClassesForKotlinIC UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE
> Task :buildSrc:assemble UP-TO-DATE
> Task :buildSrc:compileTestKotlin NO-SOURCE
> Task :buildSrc:pluginUnderTestMetadata UP-TO-DATE
> Task :buildSrc:compileTestJava NO-SOURCE
> Task :buildSrc:compileTestGroovy NO-SOURCE
> Task :buildSrc:processTestResources NO-SOURCE
> Task :buildSrc:testClasses UP-TO-DATE
> Task :buildSrc:test NO-SOURCE
> Task :buildSrc:validatePlugins UP-TO-DATE
> Task :buildSrc:check UP-TO-DATE
> Task :buildSrc:build UP-TO-DATE
> Configure project :app
ComposeOptions.kotlinCompilerVersion is deprecated. Compose now uses the kotlin compiler defined in your buildscript.
WARNING:API 'BaseVariant.getApplicationIdTextResource' is obsolete and has been replaced with 'VariantProperties.applicationId'.
It will be removed in version 7.0 of the Android Gradle plugin.
For more information, see TBD.
To determine what is calling BaseVariant.getApplicationIdTextResource, use -Pandroid.debug.obsoleteApi=true on the command line to display more information.
Warning: This version only understands SDK XML versions up to 2 but an SDK XML file of version 3 was encountered. This can happen if you use versions of Android Studio and the command-line tools that were released at different times.
Warning: unexpected element (uri:"", local:"base-extension"). Expected elements are <{}codename>,<{}layoutlib>,<{}api-level>
> Task :app:preBuild UP-TO-DATE
> Task :app:preProductionDebugBuild UP-TO-DATE
> Task :domain:compileKotlin
> Task :domain:compileJava NO-SOURCE
> Task :domain:processResources NO-SOURCE
> Task :domain:classes UP-TO-DATE
> Task :domain:inspectClassesForKotlinIC
> Task :domain:jar
> Task :data:preBuild UP-TO-DATE
> Task :data:preDebugBuild UP-TO-DATE
> Task :data:compileDebugAidl NO-SOURCE
> Task :app:compileProductionDebugAidl NO-SOURCE
> Task :data:packageDebugRenderscript NO-SOURCE
> Task :app:compileProductionDebugRenderscript NO-SOURCE
> Task :app:dataBindingMergeDependencyArtifactsProductionDebug
> Task :app:dataBindingMergeGenClassesProductionDebug
> Task :app:generateProductionDebugResValues
> Task :app:generateProductionDebugResources
> Task :data:compileDebugRenderscript NO-SOURCE
> Task :data:generateDebugResValues
> Task :data:generateDebugResources
> Task :data:packageDebugResources
> Task :app:generateProductionDebugBuildConfig
> Task :app:writeProductionDebugApplicationId
> Task :app:mergeProductionDebugResources
> Task :app:generateSafeArgsProductionDebug
> Task :app:dataBindingGenBaseClassesProductionDebug
> Task :data:writeDebugAarMetadata
> Task :app:createProductionDebugCompatibleScreenManifests
> Task :app:checkProductionDebugAarMetadata
> Task :app:extractDeepLinksProductionDebug
> Task :data:extractDeepLinksDebug
> Task :data:processDebugManifest
> Task :data:compileDebugLibraryResources
> Task :app:processProductionDebugMainManifest
> Task :app:processProductionDebugManifest
> Task :app:processProductionDebugManifestForPackage
> Task :data:generateDebugBuildConfig
> Task :data:javaPreCompileDebug
> Task :data:parseDebugLocalResources
> Task :app:javaPreCompileProductionDebug
> Task :app:extractProguardFiles
> Task :data:mergeDebugJniLibFolders
> Task :data:mergeDebugNativeLibs NO-SOURCE
> Task :data:stripDebugDebugSymbols NO-SOURCE
> Task :data:copyDebugJniLibsProjectAndLocalJars
> Task :data:mergeDebugShaders
> Task :data:compileDebugShaders NO-SOURCE
> Task :data:generateDebugAssets UP-TO-DATE
> Task :data:packageDebugAssets
> Task :data:prepareDebugArtProfile
> Task :data:prepareLintJarForPublish
> Task :data:generateDebugJacocoPropertiesFile
> Task :data:generateDebugRFile
> Task :data:processDebugJavaRes NO-SOURCE
> Task :app:processProductionDebugResources
> Task :data:compileDebugKotlin
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    /home/runner/.gradle/caches/transforms-3/e9e[8](https://github.com/nimblehq/android-templates/runs/7144340453?check_suite_focus=true#step:6:9)1ee[9](https://github.com/nimblehq/android-templates/runs/7144340453?check_suite_focus=true#step:6:10)dc284483e4f6e65b0629ea21/transformed/jetified-kotlin-reflect-1.4.31.jar (version 1.4)
    /home/runner/.gradle/caches/transforms-3/83bf5069f96e4c90557cdb2b547caf92/transformed/jetified-kotlin-stdlib-jdk8-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/transforms-3/da5fe66686e92866b987e797d6892a16/transformed/jetified-kotlin-stdlib-jdk7-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/transforms-3/a86a880af256bbeba73c1a98d2f74347/transformed/jetified-kotlin-stdlib-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/transforms-3/1497dc58f7c58748a888345c3f03af66/transformed/jetified-kotlin-stdlib-common-1.5.21.jar (version 1.5)
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
> Task :data:compileDebugJavaWithJavac
> Task :data:bundleLibCompileToJarDebug
> Task :data:jacocoDebug
> Task :app:kaptGenerateStubsProductionDebugKotlin
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    /home/runner/.gradle/caches/transforms-3/137e65dc313b7955a38fdc804b518af9/transformed/jetified-kotlin-stdlib-jdk8-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/transforms-3/e9e81ee9dc284483e4f6e65b0629ea21/transformed/jetified-kotlin-reflect-1.4.31.jar (version 1.4)
    /home/runner/.gradle/caches/transforms-3/803678b4a583bf238675366032948d7e/transformed/jetified-kotlin-stdlib-jdk7-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/transforms-3/6995e931570a3cc39e0f779125594147/transformed/jetified-kotlin-stdlib-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/transforms-3/69b58a90e1e4b1d3e4d5268e709d713e/transformed/jetified-kotlin-stdlib-common-1.5.30.jar (version 1.5)
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
> Task :data:bundleLibRuntimeToJarDebug
> Task :app:kaptProductionDebugKotlin
> Task :data:extractDebugAnnotations
> Task :app:compileProductionDebugKotlin
w: ATTENTION!
This build uses unsafe internal compiler arguments:
-XXLanguage:+NonParenthesizedAnnotationsOnFunctionalTypes
This mode is not recommended for production use,
as no stability/compatibility guarantees are given on
compiler or generated code. Use it at your own risk!
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    /home/runner/.gradle/caches/transforms-3/137e65dc313b7955a38fdc804b518af9/transformed/jetified-kotlin-stdlib-jdk8-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/transforms-3/e9e81ee9dc284483e4f6e65b0629ea21/transformed/jetified-kotlin-reflect-1.4.31.jar (version 1.4)
    /home/runner/.gradle/caches/transforms-3/803678b4a583bf238675366032948d7e/transformed/jetified-kotlin-stdlib-jdk7-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/transforms-3/6995e931570a3cc39e0f779125594147/transformed/jetified-kotlin-stdlib-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/transforms-3/69b58a90e1e4b1d3e4d5268e709d713e/transformed/jetified-kotlin-stdlib-common-1.5.30.jar (version 1.5)
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
w: /home/runner/work/android-templates/android-templates/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/di/modules/StorageModule.kt: (5, 27): 'PreferenceManager' is deprecated. Deprecated in Java
w: /home/runner/work/android-templates/android-templates/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/di/modules/StorageModule.kt: (22, 13): 'PreferenceManager' is deprecated. Deprecated in Java
w: /home/runner/work/android-templates/android-templates/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/di/modules/StorageModule.kt: (22, 31): 'getDefaultSharedPreferences(Context!): SharedPreferences!' is deprecated. Deprecated in Java
> Task :app:compileProductionDebugJavaWithJavac
> Task :data:mergeDebugGeneratedProguardFiles
> Task :data:mergeDebugConsumerProguardFiles
> Task :app:jacocoProductionDebug
> Task :data:mergeDebugJavaResource
> Task :app:transformProductionDebugClassesWithAsm
> Task :data:syncDebugLibJars
> Task :data:writeDebugLintModelMetadata
> Task :app:bundleProductionDebugClasses
> Task :data:bundleDebugLocalLintAar
> Task :data:extractProguardFiles
> Task :data:bundleLibResDebug
> Task :data:generateDebugLintModel
> Task :data:createFullJarDebug
> Task :app:generateProductionDebugLintModel
> Task :app:lintAnalyzeProductionDebug
WARNING: [Processor] Library '/home/runner/.gradle/caches/modules-2/files-2.1/org.robolectric/shadows-framework/4.3.1/da048a93951f4d9e46519749c53b0f868dfdf425/shadows-framework-4.3.1.jar' contains references to both AndroidX and old support library. This seems like the library is partially migrated. Jetifier will try to rewrite the library anyway.
 Example of androidX reference: 'androidx/test/runner/lifecycle/Stage'
 Example of support library reference: 'android/support/annotation/NonNull'
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.30/5fd47535cc85f9e24996f939c2de6583991481b0/kotlin-stdlib-jdk8-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.4.31/63db9d66c3d20f7b8f66196e7ba86969daae8b8a/kotlin-reflect-1.4.31.jar (version 1.4)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.30/525f5a7fa6d7790a571c07dd24214ed2dda352fe/kotlin-stdlib-jdk7-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.30/d68efdea04955974ac[10](https://github.com/nimblehq/android-templates/runs/7144340453?check_suite_focus=true#step:6:11)20f8f66ef8176bfbce1f/kotlin-stdlib-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.30/649ffab7767038323fec0cc41e2d7b0a8f65a378/kotlin-stdlib-common-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.5.10/d6c70f3c0df2457ea0095c61c1fc[11](https://github.com/nimblehq/android-templates/runs/7144340453?check_suite_focus=true#step:6:12)88017dc3bc/kotlin-reflect-1.5.10.jar (version 1.5)
w: Consider providing an explicit dependency on kotlin-reflect 1.5 to prevent strange errors
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
timber.lint.TimberIssueRegistry in /home/runner/.gradle/caches/transforms-3/267611858b7deb55f2eb0a1020824db4/transformed/jetified-timber-4.7.1/jars/lint.jar does not specify a vendor; see IssueRegistry#vendor
dagger.lint.DaggerIssueRegistry in /home/runner/.gradle/caches/transforms-3/bff0464bb8b6a057f2d2a20fb081d9e0/transformed/jetified-dagger-lint-aar-2.38.1/jars/lint.jar does not specify a vendor; see IssueRegistry#vendor
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.4.31/63db9d66c3d20f7b8f66196e7ba86969daae8b8a/kotlin-reflect-1.4.31.jar (version 1.4)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.21/6b3de2a43405a65502728047db37a98a0c7e72f0/kotlin-stdlib-jdk8-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.21/f059658740a4b3a3461aba9681457615332bae1c/kotlin-stdlib-jdk7-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.21/2f537cad7e9eeb9da73738c88[12](https://github.com/nimblehq/android-templates/runs/7144340453?check_suite_focus=true#step:6:13)e1e4cf9b62e4e/kotlin-stdlib-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.21/cc8bf3586fd2ebcf234058b9440bb406e62dfacb/kotlin-stdlib-common-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.5.0/47806fe8ed30dbdf9e697eda5e9c9a3905ff3363/kotlin-reflect-1.5.0.jar (version 1.5)
w: Consider providing an explicit dependency on kotlin-reflect 1.5 to prevent strange errors
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
> Task :data:lintAnalyzeDebug
> Task :data:lintDebug
Warning: Lint will treat :domain as an external dependency and not analyze it.
 * Recommended Action: Apply the 'com.android.lint' plugin to java library project :domain. to enable lint to analyze those sources.
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.4.31/63db9d66c3d20f7b8f66196e7ba86969daae8b8a/kotlin-reflect-1.4.31.jar (version 1.4)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.21/6b3de2a43405a65502728047db37a98a0c7e72f0/kotlin-stdlib-jdk8-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.21/f059658740a4b3a3461aba968[14](https://github.com/nimblehq/android-templates/runs/7144340453?check_suite_focus=true#step:6:15)576[15](https://github.com/nimblehq/android-templates/runs/7144340453?check_suite_focus=true#step:6:16)332bae1c/kotlin-stdlib-jdk7-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.21/2f537cad7e9eeb9da73738c8812e1e4cf9b62e4e/kotlin-stdlib-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.21/cc8bf3586fd2ebcf234058b9440bb406e62dfacb/kotlin-stdlib-common-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.5.0/47806fe8ed30dbdf9e697eda5e9c9a3905ff3363/kotlin-reflect-1.5.0.jar (version 1.5)
w: Consider providing an explicit dependency on kotlin-reflect 1.5 to prevent strange errors
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
> Task :data:copyDebugAndroidLintReports
Copying lint XML report to /home/runner/work/android-templates/android-templates/CoroutineTemplate/data/build/reports/lint/lint-result.xml
> Task :data:lint
> Task :app:lintProductionDebug
Warning: Lint will treat :domain as an external dependency and not analyze it.
 * Recommended Action: Apply the 'com.android.lint' plugin to java library project :domain. to enable lint to analyze those sources.
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.4.31/63db9d66c3d20f7b8f66196e7ba86969daae8b8a/kotlin-reflect-1.4.31.jar (version 1.4)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.21/6b3de2a43405a65502728047db37a98a0c7e72f0/kotlin-stdlib-jdk8-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.21/f059658740a4b3a3461aba9681457615332bae1c/kotlin-stdlib-jdk7-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.21/2f537cad7e9eeb9da73738c8812e1e4cf9b62e4e/kotlin-stdlib-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.21/cc8bf3586fd2ebcf234058b9440bb406e62dfacb/kotlin-stdlib-common-1.5.21.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.30/5fd47535cc85f9e24996f939c2de6583991481b0/kotlin-stdlib-jdk8-1.5.30.jar (version 1.5)
Wrote HTML report to file:///home/runner/work/android-templates/android-templates/CoroutineTemplate/app/build/reports/lint-results-productionDebug.html
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.30/525f5a7fa6d7790a571c07dd24214ed2dda352fe/kotlin-stdlib-jdk7-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.5.30/d68efdea04955974ac1020f8f66ef8[17](https://github.com/nimblehq/android-templates/runs/7144340453?check_suite_focus=true#step:6:18)6bfbce1f/kotlin-stdlib-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.5.30/649ffab7767038323fec0cc41e2d7b0a8f65a378/kotlin-stdlib-common-1.5.30.jar (version 1.5)
    /home/runner/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.5.10/d6c70f3c0df2457ea0095c61c1fc1[18](https://github.com/nimblehq/android-templates/runs/7144340453?check_suite_focus=true#step:6:19)8017dc3bc/kotlin-reflect-1.5.10.jar (version 1.5)
w: Consider providing an explicit dependency on kotlin-reflect 1.5 to prevent strange errors
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
> Task :app:copyProductionDebugAndroidLintReports
Copying lint XML report to /home/runner/work/android-templates/android-templates/CoroutineTemplate/app/build/reports/lint/lint-result.xml
> Task :app:lint
BUILD SUCCESSFUL in 2m [31](https://github.com/nimblehq/android-templates/runs/7144340453?check_suite_focus=true#step:6:32)s
79 actionable tasks: [67](https://github.com/nimblehq/android-templates/runs/7144340453?check_suite_focus=true#step:6:68) executed, 12 up-to-date
   ```
</details>