### PR TITLE
[#217] Increase timeout in OkHttpClient to 30 seconds

### DIFF
--- a/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/di/modules/OkHttpClientModule.kt
+++ b/CoroutineTemplate/app/src/main/java/co/nimblehq/coroutine/di/modules/OkHttpClientModule.kt
@@ -7,6 +7,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import java.util.concurrent.TimeUnit
+
+private const val READ_TIME_OUT = 30L
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -18,6 +21,7 @@ class OkHttpClientModule {
             addInterceptor(HttpLoggingInterceptor().apply {
                 level = HttpLoggingInterceptor.Level.BODY
             })
+            readTimeout(READ_TIME_OUT, TimeUnit.SECONDS)
         }
     }.build()
 }


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/217

## What happened 👀

Increase the `readTimeout` to at least 30 seconds with debug mode so that we can update the request/ response via Proxyman easier, because default they are 10 seconds which are too short

## Insight 📝

- Run example app `CoroutinesTemplate`
- Set breakpoint proxyman to `https://jsonplaceholder.typicode.com/users`
- Let the app run request `https://jsonplaceholder.typicode.com/users`
- Edit the response body to test it and wait for 10 seconds or more
- Press `execute` button on proxy man breakpoint for it to return edited response
- The response should be 200 success instead of `SocketTimeoutException`

## Proof Of Work 📹

https://user-images.githubusercontent.com/25218255/176863712-378d682a-e7ce-4875-ab35-2dc6c9dbbdf3.mov


