### PR TITLE
[#269] Fix file path error when executing new_project.kts

### DIFF
--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -139,22 +139,18 @@ object NewProject {
 
     private fun cleanNewProjectFolder() {
         executeCommand(
-            command = arrayOf(
-                "sh",
-                "$projectPath${fileSeparator}gradlew",
-                "-p",
-                "$projectPath",
-                "clean"
-            )
+            "sh",
+            "$projectPath${fileSeparator}gradlew",
+            "-p",
+            "$projectPath",
+            "clean"
         )
         executeCommand(
-            command = arrayOf(
-                "sh",
-                "$projectPath${fileSeparator}gradlew",
-                "-p",
-                "$projectPath${fileSeparator}buildSrc",
-                "clean"
-            )
+            "sh",
+            "$projectPath${fileSeparator}gradlew",
+            "-p",
+            "$projectPath${fileSeparator}buildSrc",
+            "clean"
         )
         listOf(".idea", ".gradle", "buildSrc$fileSeparator.gradle", ".git").forEach {
             File("$projectPath$fileSeparator$it")?.let { targetFile ->
@@ -240,23 +236,19 @@ object NewProject {
     private fun buildProjectAndRunTests() {
         showMessage("=> 🛠️ Building project...")
         executeCommand(
-            command = arrayOf(
-                "sh",
-                "$projectPath${fileSeparator}gradlew",
-                "-p",
-                "$projectPath",
-                "assembleDebug"
-            )
+            "sh",
+            "$projectPath${fileSeparator}gradlew",
+            "-p",
+            "$projectPath",
+            "assembleDebug"
         )
         showMessage("=> 🚓 Running tests...")
         executeCommand(
-            command = arrayOf(
-                "sh",
-                "$projectPath${fileSeparator}gradlew",
-                "-p",
-                "$projectPath",
-                "testStagingDebugUnitTest"
-            )
+            "sh",
+            "$projectPath${fileSeparator}gradlew",
+            "-p",
+            "$projectPath",
+            "testStagingDebugUnitTest"
         )
         showMessage("=> 🚀 Done! The project is ready for development")
     }
@@ -274,14 +266,15 @@ object NewProject {
      * Execute a shell command
      *
      * Runtime.getRuntime().exec(String) will partition a command automatically, based on white spaces.
-     * If a file path contains a white space, it will not be able to find the file and result in an error.
+     * If a file path contains any white spaces, it will not be able to find the file and result in an error.
      *
-     * -> Example: "Desktop/My Projects/android-templates" -> ["Desktop/My", "Projects/android-templates"]
-     * -> Reference: https://stackoverflow.com/questions/33077129/java-runtime-exec-with-white-spaces-on-path-name
+     * Example: "Desktop/My Projects/android-templates" -> ["Desktop/My", "Projects/android-templates"]
+     * Solution: Partition the command before passing it to Runtime.getRuntime().exec(String)
+     * Reference: https://stackoverflow.com/questions/33077129/java-runtime-exec-with-white-spaces-on-path-name
      *
-     * @param [command]: A command partioned in to an array of strings
+     * @param [command]: A command partitioned into multiple arguments
      */
-    private fun executeCommand(command: Array<String>) {
+    private fun executeCommand(vararg command: String) {
         val process = Runtime.getRuntime().exec(command)
         process.inputStream.reader().forEachLine { println(it) }
         process.errorStream.reader().forEachLine { println(it) }

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -138,8 +138,24 @@ object NewProject {
     }
 
     private fun cleanNewProjectFolder() {
-        executeCommand("sh $projectPath${fileSeparator}gradlew -p $projectPath clean")
-        executeCommand("sh $projectPath${fileSeparator}gradlew -p $projectPath${fileSeparator}buildSrc clean")
+        executeCommand(
+            command = arrayOf(
+                "sh",
+                "$projectPath${fileSeparator}gradlew",
+                "-p",
+                "$projectPath",
+                "clean"
+            )
+        )
+        executeCommand(
+            command = arrayOf(
+                "sh",
+                "$projectPath${fileSeparator}gradlew",
+                "-p",
+                "$projectPath${fileSeparator}buildSrc",
+                "clean"
+            )
+        )
         listOf(".idea", ".gradle", "buildSrc$fileSeparator.gradle", ".git").forEach {
             File("$projectPath$fileSeparator$it")?.let { targetFile ->
                 targetFile.deleteRecursively()
@@ -223,9 +239,25 @@ object NewProject {
 
     private fun buildProjectAndRunTests() {
         showMessage("=> 🛠️ Building project...")
-        executeCommand("sh $projectPath${fileSeparator}gradlew -p $projectPath assembleDebug")
+        executeCommand(
+            command = arrayOf(
+                "sh",
+                "$projectPath${fileSeparator}gradlew",
+                "-p",
+                "$projectPath",
+                "assembleDebug"
+            )
+        )
         showMessage("=> 🚓 Running tests...")
-        executeCommand("sh $projectPath${fileSeparator}gradlew -p $projectPath testStagingDebugUnitTest")
+        executeCommand(
+            command = arrayOf(
+                "sh",
+                "$projectPath${fileSeparator}gradlew",
+                "-p",
+                "$projectPath",
+                "testStagingDebugUnitTest"
+            )
+        )
         showMessage("=> 🚀 Done! The project is ready for development")
     }
 
@@ -238,9 +270,21 @@ object NewProject {
         }
     }
 
-    private fun executeCommand(command: String) {
+    /**
+     * Execute a shell command
+     *
+     * Runtime.getRuntime().exec(String) will partition a command automatically, based on white spaces.
+     * If a file path contains a white space, it will not be able to find the file and result in an error.
+     *
+     * -> Example: "Desktop/My Projects/android-templates" -> ["Desktop/My", "Projects/android-templates"]
+     * -> Reference: https://stackoverflow.com/questions/33077129/java-runtime-exec-with-white-spaces-on-path-name
+     *
+     * @param [command]: A command partioned in to an array of strings
+     */
+    private fun executeCommand(command: Array<String>) {
         val process = Runtime.getRuntime().exec(command)
         process.inputStream.reader().forEachLine { println(it) }
+        process.errorStream.reader().forEachLine { println(it) }
         val exitValue = process.waitFor()
         if (exitValue != 0) {
             showMessage(


### PR DESCRIPTION
Closes #269 

## What happened 👀
`Runtime.getRuntime().exec(String)` will partition a command automatically, based on white spaces.
If a file path contains a white space, it will not be able to find the file and result in an error.
     
-> **Example**: "Desktop/My Projects/android-templates" -> ["Desktop/My", "Projects/android-templates"]
-> **Reference**: https://stackoverflow.com/questions/33077129/java-runtime-exec-with-white-spaces-on-path-name

## Insight 📝

Preferably I don't want to pass an array of Strings, so initially, so I tried the following:

- I tried escaping the white space (`\`)
- I tried encoding the white space (`%20)`
- I tried wrapping the file path with quotes
- I tried splitting up the command into an array, with regular expressions

Unfortunately, I couldn't make it work with these approaches

Please let me know if anyone has a better solution 🙏 

## Proof Of Work 📹

Script can run successfully if file path contains a white space:
https://user-images.githubusercontent.com/18277915/184601355-6352ca8e-4d8b-466f-8130-a33b4c8ee384.mov

