### PR TITLE
[#275] Fix references when generating a new project

### DIFF
--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -2,16 +2,20 @@ import java.io.File
 
 object NewProject {
 
-    private const val ARGUMENT_DELIMITER = "="
+    private const val DELIMITER_ARGUMENT = "="
+
     private const val KEY_APP_NAME = "app-name"
     private const val KEY_HELP = "--help"
     private const val KEY_PACKAGE_NAME = "package-name"
+
     private const val PATTERN_APP = "^([A-Z][a-zA-Z0-9\\s]*)|([a-z][a-z0-9-]*)$"
     private const val PATTERN_PACKAGE = "^[a-z]+(\\.[a-z][a-z0-9]*)+$"
+
     private const val SEPARATOR_DOT = "."
     private const val SEPARATOR_MINUS = "-"
     private const val SEPARATOR_SLASH = "/"
     private const val SEPARATOR_SPACE = " "
+
     private const val TEMPLATE_APP_NAME = "Template"
     private const val TEMPLATE_APPLICATION_CLASS_NAME = "TemplateApplication"
     private const val TEMPLATE_FOLDER_NAME = "template"
@@ -79,13 +83,13 @@ object NewProject {
                         exitAfterMessage = true
                     )
                 }
-                arg.startsWith("$KEY_APP_NAME$ARGUMENT_DELIMITER") -> {
-                    val (key, value) = arg.split(ARGUMENT_DELIMITER)
+                arg.startsWith("$KEY_APP_NAME$DELIMITER_ARGUMENT") -> {
+                    val (key, value) = arg.split(DELIMITER_ARGUMENT)
                     validateAppName(value)
                     hasAppName = true
                 }
-                arg.startsWith("$KEY_PACKAGE_NAME$ARGUMENT_DELIMITER") -> {
-                    val (key, value) = arg.split(ARGUMENT_DELIMITER)
+                arg.startsWith("$KEY_PACKAGE_NAME$DELIMITER_ARGUMENT") -> {
+                    val (key, value) = arg.split(DELIMITER_ARGUMENT)
                     validatePackageName(value)
                     hasPackageName = true
                 }
@@ -204,14 +208,16 @@ object NewProject {
             .walk()
             .filter { it.name.endsWithAny(".kt", ".xml", ".gradle.kts") }
             .forEach { filePath ->
-                if (filePath.name == "jacoco-report.gradle.kts") {
-                    rename(
+                when (filePath.name) {
+                    "jacoco-report.gradle.kts" -> rename(
                         sourcePath = filePath.toString(),
-                        oldValue = TEMPLATE_PACKAGE_NAME.replace(SEPARATOR_DOT, SEPARATOR_SLASH),
+                        oldValue = TEMPLATE_PACKAGE_NAME.replace(
+                            SEPARATOR_DOT,
+                            SEPARATOR_SLASH
+                        ),
                         newValue = packageName.replace(SEPARATOR_DOT, SEPARATOR_SLASH)
                     )
-                } else {
-                    rename(
+                    else -> rename(
                         sourcePath = filePath.toString(),
                         oldValue = TEMPLATE_PACKAGE_NAME,
                         newValue = packageName

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -202,11 +202,7 @@ object NewProject {
         showMessage("=> 🔎 Renaming package name within files...")
         File(projectPath)
             .walk()
-            .filter {
-                it.name.endsWith(".kt")
-                        || it.name.endsWith(".xml")
-                        || it.name.endsWith(".gradle.kts")
-            }
+            .filter { it.name.endsWithAny(".kt", ".xml", ".gradle.kts") }
             .forEach { filePath ->
                 if (filePath.name == "jacoco-report.gradle.kts") {
                     rename(
@@ -339,6 +335,10 @@ object NewProject {
 
     private fun String.getStringWithoutSpace(): String {
         return this.replace(SEPARATOR_SPACE, "")
+    }
+
+    private fun String.endsWithAny(vararg suffixes: String): Boolean {
+        return suffixes.any { endsWith(it) }
     }
 }
 

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -10,6 +10,7 @@ object NewProject {
     private const val PATTERN_PACKAGE = "^[a-z]+(\\.[a-z][a-z0-9]*)+$"
     private const val SEPARATOR_DOT = "."
     private const val SEPARATOR_MINUS = "-"
+    private const val SEPARATOR_SLASH = "/"
     private const val SEPARATOR_SPACE = " "
     private const val TEMPLATE_APP_NAME = "Template"
     private const val TEMPLATE_APPLICATION_CLASS_NAME = "TemplateApplication"
@@ -201,13 +202,25 @@ object NewProject {
         showMessage("=> 🔎 Renaming package name within files...")
         File(projectPath)
             .walk()
-            .filter { it.name.endsWith(".kt") || it.name.endsWith(".xml") }
+            .filter {
+                it.name.endsWith(".kt")
+                        || it.name.endsWith(".xml")
+                        || it.name.endsWith(".gradle.kts")
+            }
             .forEach { filePath ->
-                rename(
-                    sourcePath = filePath.toString(),
-                    oldValue = TEMPLATE_PACKAGE_NAME,
-                    newValue = packageName
-                )
+                if (filePath.name == "jacoco-report.gradle.kts") {
+                    rename(
+                        sourcePath = filePath.toString(),
+                        oldValue = TEMPLATE_PACKAGE_NAME.replace(SEPARATOR_DOT, SEPARATOR_SLASH),
+                        newValue = packageName.replace(SEPARATOR_DOT, SEPARATOR_SLASH)
+                    )
+                } else {
+                    rename(
+                        sourcePath = filePath.toString(),
+                        oldValue = TEMPLATE_PACKAGE_NAME,
+                        newValue = packageName
+                    )
+                }
             }
     }
 

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -3,14 +3,14 @@ import java.io.File
 object NewProject {
 
     private const val ARGUMENT_DELIMITER = "="
-    private const val DOT_SEPARATOR = "."
     private const val KEY_APP_NAME = "app-name"
     private const val KEY_HELP = "--help"
     private const val KEY_PACKAGE_NAME = "package-name"
-    private const val MINUS_SEPARATOR = "-"
     private const val PATTERN_APP = "^([A-Z][a-zA-Z0-9\\s]*)|([a-z][a-z0-9-]*)$"
     private const val PATTERN_PACKAGE = "^[a-z]+(\\.[a-z][a-z0-9]*)+$"
-    private const val SPACE_SEPARATOR = " "
+    private const val SEPARATOR_DOT = "."
+    private const val SEPARATOR_MINUS = "-"
+    private const val SEPARATOR_SPACE = " "
     private const val TEMPLATE_APP_NAME = "Template"
     private const val TEMPLATE_APPLICATION_CLASS_NAME = "TemplateApplication"
     private const val TEMPLATE_FOLDER_NAME = "template"
@@ -30,9 +30,9 @@ object NewProject {
 
     private var appName: String = ""
         set(value) {
-            field = if (value.contains(MINUS_SEPARATOR)) {
+            field = if (value.contains(SEPARATOR_MINUS)) {
                 projectFolderName = value
-                value.replace(MINUS_SEPARATOR, SPACE_SEPARATOR).uppercaseEveryFirstCharacter()
+                value.replace(SEPARATOR_MINUS, SEPARATOR_SPACE).uppercaseEveryFirstCharacter()
             } else {
                 value.uppercaseEveryFirstCharacter().also {
                     projectFolderName = it.getStringWithoutSpace()
@@ -170,13 +170,13 @@ object NewProject {
                 .forEach { javaDirectory ->
                     val oldDirectory = File(
                         javaDirectory, TEMPLATE_PACKAGE_NAME.replace(
-                            oldValue = DOT_SEPARATOR,
+                            oldValue = SEPARATOR_DOT,
                             newValue = fileSeparator
                         )
                     )
                     val newDirectory = File(
                         javaDirectory, packageName.replace(
-                            oldValue = DOT_SEPARATOR,
+                            oldValue = SEPARATOR_DOT,
                             newValue = fileSeparator
                         )
                     )
@@ -319,13 +319,13 @@ object NewProject {
     }
 
     private fun String.uppercaseEveryFirstCharacter(): String {
-        return this.split(SPACE_SEPARATOR).joinToString(separator = SPACE_SEPARATOR) { string ->
+        return this.split(SEPARATOR_SPACE).joinToString(separator = SEPARATOR_SPACE) { string ->
             string.replaceFirstChar { it.uppercase() }
         }
     }
 
     private fun String.getStringWithoutSpace(): String {
-        return this.replace(SPACE_SEPARATOR, "")
+        return this.replace(SEPARATOR_SPACE, "")
     }
 }
 

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,5 +1,5 @@
 # Created by .ignore support plugin (hsz.mobi)
-### Android template
+
 # Built application files
 *.apk
 *.ap_
@@ -29,7 +29,6 @@ proguard/
 # Log Files
 *.log
 
-
 # Android Studio captures folder
 captures/
 
@@ -48,5 +47,6 @@ jacoco.exec
 
 # Google services
 google-services.json
+
 # Keystore
 config/release.keystore

--- a/template/README.md
+++ b/template/README.md
@@ -48,4 +48,4 @@ Report is located at: `./app/build/reports/jacoco/`
 For `release` builds, we need to provide release keystore and signing properties:
 
 - Put the `release.keystore` file at root `config` folder.
-- Put keystore signing properties in [signing.properties](https://github.com/nimblehq/android-templates/blob/develop/template/signing.properties).
+- Put keystore signing properties in `signing.properties`


### PR DESCRIPTION
Closes #275

## What happened 👀

- Update forgotten files when running `new_project.kts`:

  - `app/build.gradle.kts` : Rename package name in `applicationId`
  - `jacoco-report.gradle.kts` : Rename package name in `packagesExcluded`
- Refactor `SEPARATOR` const variables so they can be grouped
- Clean up `README.md`: To keep it simple, just remove the link
- Clean up `.gitignore`

## Proof Of Work 📹


https://user-images.githubusercontent.com/18277915/184790619-1a4b155d-8d24-4d07-bc5f-bfc9db217da3.mp4
