### PR TITLE
[#285] Print failed command when execution fails

### DIFF
--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -298,7 +298,7 @@ object NewProject {
         val exitValue = process.waitFor()
         if (exitValue != 0) {
             showMessage(
-                message = "❌ Something went wrong! when executing command: $command",
+                message = "❌ Something went wrong! when executing command: ${command.joinToString(" ")}",
                 exitAfterMessage = true,
                 exitValue = exitValue
             )


### PR DESCRIPTION
closes #285 

## What happened 👀

- Added `joinToString(" ")` call when printing `command` to print the issued command

## Proof Of Work 📹

<img width="833" alt="Screenshot 2565-08-23 at 17 11 40" src="https://user-images.githubusercontent.com/53168251/186133922-b583b377-d164-4966-8d30-527ad413530e.png">

