### PR TITLE
[#282] Support running new_project.kts from project root folder

### DIFF
--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -59,7 +59,13 @@ object NewProject {
         get() = rootPath + projectFolderName
 
     private val rootPath: String
-        get() = System.getProperty("user.dir").replace("scripts", "")
+        get() = System.getProperty("user.dir").let { userDir ->
+            if (userDir.endsWith("/scripts")) {
+                userDir.substring(0, userDir.lastIndexOf("scripts"))
+            } else {
+                userDir + "/"
+            }
+        }
 
     fun generate(args: Array<String>) {
         handleArguments(args)

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -11,6 +11,8 @@ object NewProject {
     private const val PATTERN_APP = "^([A-Z][a-zA-Z0-9\\s]*)|([a-z][a-z0-9-]*)$"
     private const val PATTERN_PACKAGE = "^[a-z]+(\\.[a-z][a-z0-9]*)+$"
 
+    private const val SCRIPTS_FOLDER_NAME = "scripts"
+
     private const val SEPARATOR_DOT = "."
     private const val SEPARATOR_MINUS = "-"
     private const val SEPARATOR_SLASH = "/"
@@ -26,7 +28,9 @@ object NewProject {
             package-name=   New package name (i.e., com.example.package)
             app-name=       New app name (i.e., MyApp, "My App", "my-app")
         
-        Example: kscript new_project.kts package-name=co.myproject.example app-name="My Project"
+        Examples:
+            kscript new_project.kts package-name=co.myproject.example app-name="My Project"
+            kscript scripts/new_project.kts package-name=co.myproject.example app-name="My Project"
     """.trimIndent()
 
     private val modules = listOf("app", "data", "domain")
@@ -60,10 +64,10 @@ object NewProject {
 
     private val rootPath: String
         get() = System.getProperty("user.dir").let { userDir ->
-            if (userDir.endsWith("/scripts")) {
-                userDir.substring(0, userDir.lastIndexOf("scripts"))
+            if (userDir.endsWith("$fileSeparator$SCRIPTS_FOLDER_NAME")) {
+                userDir.substring(0, userDir.lastIndexOf(SCRIPTS_FOLDER_NAME))
             } else {
-                userDir + "/"
+                "$userDir$fileSeparator"
             }
         }
 


### PR DESCRIPTION
Closes #282 

## What happened 👀

Fixed issue with `new_project.kts` not running properly from root folder.
Also fixed issue when generating a new project and file path contains `scripts` anywhere before the last segment.

## Insight 📝

- Added check if current directory ends with `/scripts`
- If yes, remove last segment.
- If no, keep path as is and append `/`

## Proof Of Work 📹

Note: PoW captured by printing `rootPath`, `projectPath` and `ProjectFolderName` values

Old script from path that contains `script`
<img width="1133" alt="Screenshot 2565-08-24 at 14 46 01" src="https://user-images.githubusercontent.com/53168251/186363499-61c14cc3-fce3-4aa3-862c-0be8bbfa0de3.png">

New script from path that contains `scripts`
<img width="1134" alt="Screenshot 2565-08-24 at 14 46 30" src="https://user-images.githubusercontent.com/53168251/186363781-58dcd8fa-d8c4-41c2-80c1-816a05091bae.png">

New script from root folder
<img width="1141" alt="Screenshot 2565-08-24 at 14 48 35" src="https://user-images.githubusercontent.com/53168251/186363877-9b150645-4370-4633-8137-1dd26077ae87.png">

New script from `/scripts` folder
<img width="982" alt="Screenshot 2565-08-24 at 14 48 43" src="https://user-images.githubusercontent.com/53168251/186363912-42014aee-0ed0-4a4a-a78a-ee98686248ca.png">


