### PR TITLE
[#242] Add divider for last item in Compose sample

### DIFF
--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
@@ -1,7 +1,7 @@
 package co.nimblehq.sample.compose.ui.screens.home
 
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
@@ -14,7 +14,7 @@ fun ItemList(
     onItemClick: (UiModel) -> Unit
 ) {
     LazyColumn {
-        itemsIndexed(items = uiModels) { _, uiModel ->
+        items(uiModels) { uiModel ->
             Item(
                 uiModel = uiModel,
                 onClick = onItemClick

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
@@ -14,12 +14,12 @@ fun ItemList(
     onItemClick: (UiModel) -> Unit
 ) {
     LazyColumn {
-        itemsIndexed(items = uiModels) { index, uiModel ->
+        itemsIndexed(items = uiModels) { _, uiModel ->
             Item(
                 uiModel = uiModel,
                 onClick = onItemClick
             )
-            if (index != uiModels.lastIndex) Divider()
+            Divider()
         }
     }
 }


### PR DESCRIPTION
Closes #242 

## What happened 👀

According to [this discussion](https://github.com/nimblehq/android-templates/pull/281#discussion_r954672390), we need to add a divider for the last item in Compose sample for the sake of consistency on both sample

## Insight 📝

- [x] Remove hiding divider on the last item logic in Compose sample

## Proof Of Work 📹

![Screenshot_20220826_101843](https://user-images.githubusercontent.com/13492460/186810469-acfa072c-2bd7-4ee7-905a-fba7b01070ba.png)
