### PR TITLE
[#213] [1/2 - Template] Apply to use Flow + get rid of custom UseCaseResult

### DIFF
--- a/template/app/src/main/java/co/nimblehq/template/ui/screens/compose/HomeComposeViewModel.kt
+++ b/template/app/src/main/java/co/nimblehq/template/ui/screens/compose/HomeComposeViewModel.kt
@@ -1,14 +1,12 @@
 package co.nimblehq.template.ui.screens.compose
 
 import co.nimblehq.template.domain.usecase.UseCase
-import co.nimblehq.template.domain.usecase.UseCaseResult
 import co.nimblehq.template.model.UiModel
 import co.nimblehq.template.model.toUiModels
 import co.nimblehq.template.ui.base.BaseViewModel
 import co.nimblehq.template.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,16 +21,17 @@ class HomeComposeViewModel @Inject constructor(
 
     init {
         execute {
-            when (val result = useCase.execute()) {
-                is UseCaseResult.Success -> {
-                    val uiModels = result.data.toUiModels()
-                    _uiModels.emit(uiModels)
-                }
-                is UseCaseResult.Error -> {
-                    val errorMessage = result.exception.message.orEmpty()
+            showLoading()
+            useCase.execute()
+                .catch {
+                    val errorMessage = it.message.orEmpty()
                     _error.emit(errorMessage)
                 }
-            }
+                .collect { result ->
+                    val uiModels = result.toUiModels()
+                    _uiModels.emit(uiModels)
+                }
+            hideLoading()
         }
     }
 }

--- a/template/app/src/main/java/co/nimblehq/template/ui/screens/xml/HomeViewModel.kt
+++ b/template/app/src/main/java/co/nimblehq/template/ui/screens/xml/HomeViewModel.kt
@@ -1,14 +1,12 @@
 package co.nimblehq.template.ui.screens.xml
 
 import co.nimblehq.template.domain.usecase.UseCase
-import co.nimblehq.template.domain.usecase.UseCaseResult
 import co.nimblehq.template.model.UiModel
 import co.nimblehq.template.model.toUiModels
 import co.nimblehq.template.ui.base.BaseViewModel
 import co.nimblehq.template.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,16 +21,17 @@ class HomeViewModel @Inject constructor(
 
     init {
         execute {
-            when (val result = useCase.execute()) {
-                is UseCaseResult.Success -> {
-                    val uiModels = result.data.toUiModels()
-                    _uiModels.emit(uiModels)
-                }
-                is UseCaseResult.Error -> {
-                    val errorMessage = result.exception.message.orEmpty()
+            showLoading()
+            useCase.execute()
+                .catch {
+                    val errorMessage = it.message.orEmpty()
                     _error.emit(errorMessage)
                 }
-            }
+                .collect { result ->
+                    val uiModels = result.toUiModels()
+                    _uiModels.emit(uiModels)
+                }
+            hideLoading()
         }
     }
 }

--- a/template/data/build.gradle.kts
+++ b/template/data/build.gradle.kts
@@ -64,6 +64,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN_VERSION}")
     implementation("javax.inject:javax.inject:${Versions.JAVAX_INJECT_VERSION}")
 
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.KOTLINX_COROUTINES_VERSION}")
+
     api("com.squareup.retrofit2:converter-moshi:${Versions.RETROFIT_VERSION}")
     api("com.squareup.retrofit2:retrofit:${Versions.RETROFIT_VERSION}")
 

--- a/template/data/src/main/java/co/nimblehq/template/data/repository/RepositoryImpl.kt
+++ b/template/data/src/main/java/co/nimblehq/template/data/repository/RepositoryImpl.kt
@@ -4,10 +4,19 @@ import co.nimblehq.template.data.response.toModels
 import co.nimblehq.template.data.service.ApiService
 import co.nimblehq.template.domain.model.Model
 import co.nimblehq.template.domain.repository.Repository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class RepositoryImpl constructor(
     private val apiService: ApiService
 ) : Repository {
 
-    override suspend fun getModels(): List<Model> = apiService.getResponses().toModels()
+    override fun getModels(): Flow<List<Model>> = flow {
+        try {
+            val result = apiService.getResponses().toModels()
+            emit(result)
+        } catch (e: Exception) {
+            throw e
+        }
+    }
 }

--- a/template/data/src/test/java/co/nimblehq/template/data/repository/RepositoryTest.kt
+++ b/template/data/src/test/java/co/nimblehq/template/data/repository/RepositoryTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
 import org.junit.Test
@@ -32,13 +33,18 @@ class RepositoryTest {
         val expected = listOf(response)
         coEvery { mockService.getResponses() } returns expected
 
-        repository.getModels() shouldBe expected.toModels()
+        repository.getModels().collect {
+            it shouldBe expected.toModels()
+        }
     }
 
     @Test
     fun `When request failed, it returns error`() = runBlockingTest {
-        coEvery { mockService.getResponses() } throws Throwable()
+        val expected = Throwable()
+        coEvery { mockService.getResponses() } throws expected
 
-        shouldThrow<Throwable> { repository.getModels() }
+        repository.getModels().catch {
+            it shouldBe expected
+        }.collect()
     }
 }

--- a/template/domain/build.gradle.kts
+++ b/template/domain/build.gradle.kts
@@ -12,6 +12,7 @@ java {
 
 dependencies {
     implementation("javax.inject:javax.inject:${Versions.JAVAX_INJECT_VERSION}")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.KOTLINX_COROUTINES_VERSION}")
 
     // Testing
     testImplementation("junit:junit:${Versions.TEST_JUNIT_VERSION}")

--- a/template/domain/src/main/java/co/nimblehq/template/domain/repository/Repository.kt
+++ b/template/domain/src/main/java/co/nimblehq/template/domain/repository/Repository.kt
@@ -1,8 +1,9 @@
 package co.nimblehq.template.domain.repository
 
 import co.nimblehq.template.domain.model.Model
+import kotlinx.coroutines.flow.Flow
 
 interface Repository {
 
-    suspend fun getModels(): List<Model>
+    fun getModels(): Flow<List<Model>>
 }

--- a/template/domain/src/main/java/co/nimblehq/template/domain/usecase/UseCase.kt
+++ b/template/domain/src/main/java/co/nimblehq/template/domain/usecase/UseCase.kt
@@ -2,16 +2,12 @@ package co.nimblehq.template.domain.usecase
 
 import co.nimblehq.template.domain.model.Model
 import co.nimblehq.template.domain.repository.Repository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class UseCase @Inject constructor(private val repository: Repository) {
 
-    suspend fun execute(): UseCaseResult<List<Model>> {
-        return try {
-            val response = repository.getModels()
-            UseCaseResult.Success(response)
-        } catch (e: IllegalStateException) {
-            UseCaseResult.Error(e)
-        }
+    fun execute(): Flow<List<Model>> {
+        return repository.getModels()
     }
 }

--- a/template/domain/src/main/java/co/nimblehq/template/domain/usecase/UseCaseResult.kt
+++ b/template/domain/src/main/java/co/nimblehq/template/domain/usecase/UseCaseResult.kt
@@ -1,6 +1,0 @@
-package co.nimblehq.template.domain.usecase
-
-sealed class UseCaseResult<out T : Any?> {
-    class Success<out T : Any>(val data: T) : UseCaseResult<T>()
-    class Error(val exception: Throwable) : UseCaseResult<Nothing>()
-}

--- a/template/domain/src/test/java/co/nimblehq/template/domain/usecase/UseCaseTest.kt
+++ b/template/domain/src/test/java/co/nimblehq/template/domain/usecase/UseCaseTest.kt
@@ -3,9 +3,9 @@ package co.nimblehq.template.domain.usecase
 import co.nimblehq.template.domain.model.Model
 import co.nimblehq.template.domain.repository.Repository
 import io.kotest.matchers.shouldBe
-import io.mockk.coEvery
-import io.mockk.mockk
+import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
 import org.junit.Test
@@ -27,20 +27,20 @@ class UseCaseTest {
     @Test
     fun `When request successful, it returns success`() = runBlockingTest {
         val expected = listOf(model)
-        coEvery { mockRepository.getModels() } returns expected
+        every { mockRepository.getModels() } returns flowOf(expected)
 
-        useCase.execute().run {
-            (this as UseCaseResult.Success).data shouldBe expected
+        useCase.execute().collect {
+            it shouldBe expected
         }
     }
 
     @Test
     fun `When request failed, it returns error`() = runBlockingTest {
-        val expected = IllegalStateException()
-        coEvery { mockRepository.getModels() } throws expected
+        val expected = Exception()
+        every { mockRepository.getModels() } returns flow { throw expected }
 
-        useCase.execute().run {
-            (this as UseCaseResult.Error).exception shouldBe expected
-        }
+        useCase.execute().catch {
+            it shouldBe expected
+        }.collect()
     }
 }


### PR DESCRIPTION
Resolves https://github.com/nimblehq/android-templates/issues/213

## What happened 👀

- Apply to use [Flow](https://developer.android.com/kotlin/flow) to transfer the data from `Repository` through `UseCase` to `ViewModel`.
- Get rid of duplicating a new **try/catch** block in both `UseCase` and `Repository` when implementing https://github.com/nimblehq/android-templates/issues/212 as we can't access `retrofit objects` such as [HttpException](https://square.github.io/retrofit/2.x/retrofit/retrofit2/HttpException.html) in UseCase layer.
- Get rid of using a custom `UseCaseResult` to transfer data and exception from Usecase to ViewModel.
- Update all ViewModel logics and samples to adapt new structure.

## Insight 📝

- I don't think we should apply to use a custom `UseCaseResult` or even built-in [Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/), we can rely on kotlin.Flow to catch the error or collect data flow properly. 🤓 

## Proof Of Work 📹

The `template` app should work properly after migrating.
