### PR TITLE
[#264] Add version for new_project.kts to a properties file

### DIFF
--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -13,7 +13,6 @@ object NewProject {
     private const val PATTERN_PACKAGE = "^[a-z]+(\\.[a-z][a-z0-9]*)+$"
 
     private const val SCRIPTS_FOLDER_NAME = "scripts"
-
     private const val SCRIPT_VERSION_PROPERTY_NAME = "templateScriptVersion"
     private const val SEPARATOR_DOT = "."
     private const val SEPARATOR_MINUS = "-"
@@ -76,6 +75,7 @@ object NewProject {
         }
 
     fun generate(args: Array<String>) {
+        showScriptVersion()
         handleArguments(args)
         initializeNewProjectFolder()
         cleanNewProjectFolder()
@@ -89,7 +89,7 @@ object NewProject {
     private fun showScriptVersion() {
         val properties = File(rootPath).loadProperties(VERSION_FILE_NAME)
         val scriptVersion = properties.getProperty(SCRIPT_VERSION_PROPERTY_NAME) as String
-        showMessage(message = "=> Running new project script version $scriptVersion... \uD83D\uDC4B")
+        showMessage(message = "=> \uD83D\uDC4B Running new project script version $scriptVersion... ")
     }
 
     private fun handleArguments(args: Array<String>) {
@@ -98,7 +98,6 @@ object NewProject {
         args.forEach { arg ->
             when {
                 arg == KEY_HELP -> {
-                    showScriptVersion()
                     showMessage(
                         message = helpMessage,
                         exitAfterMessage = true

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -1,4 +1,5 @@
 import java.io.File
+import java.util.Properties
 
 object NewProject {
 
@@ -13,6 +14,7 @@ object NewProject {
 
     private const val SCRIPTS_FOLDER_NAME = "scripts"
 
+    private const val SCRIPT_VERSION_PROPERTY_NAME = "templateScriptVersion"
     private const val SEPARATOR_DOT = "."
     private const val SEPARATOR_MINUS = "-"
     private const val SEPARATOR_SLASH = "/"
@@ -22,6 +24,8 @@ object NewProject {
     private const val TEMPLATE_APPLICATION_CLASS_NAME = "TemplateApplication"
     private const val TEMPLATE_FOLDER_NAME = "template"
     private const val TEMPLATE_PACKAGE_NAME = "co.nimblehq.template"
+
+    private const val VERSION_FILE_NAME = "version.properties"
 
     private val helpMessage = """
         Run kscript new_project.kts to create a new project with the following arguments:
@@ -82,12 +86,19 @@ object NewProject {
         buildProjectAndRunTests()
     }
 
+    private fun showScriptVersion() {
+        val properties = File(rootPath).loadProperties(VERSION_FILE_NAME)
+        val scriptVersion = properties.getProperty(SCRIPT_VERSION_PROPERTY_NAME) as String
+        showMessage(message = "=> Running new project script version $scriptVersion... \uD83D\uDC4B")
+    }
+
     private fun handleArguments(args: Array<String>) {
         var hasAppName = false
         var hasPackageName = false
         args.forEach { arg ->
             when {
                 arg == KEY_HELP -> {
+                    showScriptVersion()
                     showMessage(
                         message = helpMessage,
                         exitAfterMessage = true
@@ -357,6 +368,16 @@ object NewProject {
 
     private fun String.endsWithAny(vararg suffixes: String): Boolean {
         return suffixes.any { endsWith(it) }
+    }
+
+    private fun File.loadProperties(fileName: String): Properties {
+        val properties = Properties()
+        val propertiesFile = File(this, fileName)
+
+        if (propertiesFile.isFile) {
+            properties.load(propertiesFile.inputStream())
+        }
+        return properties
     }
 }
 

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,1 @@
+templateScriptVersion=3.12.0


### PR DESCRIPTION
closes #264 

## What happened 👀

Versioning is useful so that the script can be reported or referenced with the version.

This issue consists of three parts:

**Part 1 : Set-up the properties file**
1. Add `version.properties` to the root folder (if it doesn't already exist)
2. Add a property to indicate the current version of `new_project.kts` → `3.12.0` **(A)** 

**Part 2 : Use the properties file**
When running `new_project.kts`, it must show a message: `"=> Running new project script version **(A)**... 👋" 

**Part 3 : Update documentation**
Update output message with **(A)** when executing `kscript new_project.kts --help`

## Insight 📝

- Add `version.properties` file at the root folder
- Add property with value
- Show version message when executing `kscript new_project.kts --help`

## Proof Of Work 📹


![Screen Shot 2022-09-15 at 12 09 58 PM](https://user-images.githubusercontent.com/32578035/190320348-8fa4ecf5-5488-4a36-803c-8c20986c9e32.png)


