### PR TITLE
[#212] Add flowTransform to map and handle custom errors as Flow in data layer

### DIFF
--- a/template/data/src/main/java/co/nimblehq/template/data/extensions/ResponseMapping.kt
+++ b/template/data/src/main/java/co/nimblehq/template/data/extensions/ResponseMapping.kt
@@ -1,0 +1,53 @@
+package co.nimblehq.template.data.extensions
+
+import co.nimblehq.template.data.response.ErrorResponse
+import co.nimblehq.template.data.service.ApiException
+import co.nimblehq.template.data.service.NoConnectivityException
+import co.nimblehq.template.data.service.providers.MoshiBuilderProvider
+import com.squareup.moshi.JsonDataException
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import retrofit2.HttpException
+import java.io.IOException
+import java.io.InterruptedIOException
+import java.net.UnknownHostException
+import kotlin.experimental.ExperimentalTypeInference
+
+@Suppress("TooGenericExceptionCaught")
+@OptIn(ExperimentalTypeInference::class)
+fun <T> flowTransform(@BuilderInference block: suspend FlowCollector<T>.() -> T) = flow {
+    val result = try {
+        block()
+    } catch (e: Exception) {
+        throw e.mapError()
+    }
+    emit(result)
+}
+
+private fun Throwable.mapError(): Throwable {
+    return when (this) {
+        is UnknownHostException, is InterruptedIOException -> NoConnectivityException
+        is HttpException -> {
+            val errorResponse = parseErrorResponse(this)
+            ApiException(errorResponse, response())
+        }
+        else -> this
+    }
+}
+
+private fun parseErrorResponse(httpException: HttpException): ErrorResponse? {
+    val jsonString = httpException.response()?.errorBody()?.string()
+    return parseErrorResponse(jsonString)
+}
+
+private fun parseErrorResponse(jsonString: String?): ErrorResponse? {
+    return try {
+        val moshi = MoshiBuilderProvider.moshiBuilder.build()
+        val adapter = moshi.adapter(ErrorResponse::class.java)
+        adapter.fromJson(jsonString.orEmpty())
+    } catch (exception: IOException) {
+        null
+    } catch (exception: JsonDataException) {
+        null
+    }
+}

--- a/template/data/src/main/java/co/nimblehq/template/data/repository/RepositoryImpl.kt
+++ b/template/data/src/main/java/co/nimblehq/template/data/repository/RepositoryImpl.kt
@@ -1,23 +1,17 @@
 package co.nimblehq.template.data.repository
 
+import co.nimblehq.template.data.extensions.flowTransform
 import co.nimblehq.template.data.response.toModels
 import co.nimblehq.template.data.service.ApiService
 import co.nimblehq.template.domain.model.Model
 import co.nimblehq.template.domain.repository.Repository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 
 class RepositoryImpl constructor(
     private val apiService: ApiService
 ) : Repository {
 
-    override fun getModels(): Flow<List<Model>> = flow {
-        try {
-            val result = apiService.getResponses().toModels()
-            emit(result)
-        } catch (exception: Exception) {
-            // TODO do error mapping here
-            throw exception
-        }
+    override fun getModels(): Flow<List<Model>> = flowTransform {
+        apiService.getResponses().toModels()
     }
 }

--- a/template/data/src/main/java/co/nimblehq/template/data/response/ErrorResponse.kt
+++ b/template/data/src/main/java/co/nimblehq/template/data/response/ErrorResponse.kt
@@ -1,0 +1,8 @@
+package co.nimblehq.template.data.response
+
+import com.squareup.moshi.Json
+
+data class ErrorResponse(
+    @Json(name = "message")
+    val message: String
+)

--- a/template/data/src/main/java/co/nimblehq/template/data/service/Exceptions.kt
+++ b/template/data/src/main/java/co/nimblehq/template/data/service/Exceptions.kt
@@ -1,0 +1,12 @@
+package co.nimblehq.template.data.service
+
+import co.nimblehq.template.data.response.ErrorResponse
+import retrofit2.HttpException
+import retrofit2.Response
+
+object NoConnectivityException : RuntimeException()
+
+data class ApiException(
+    val error: ErrorResponse?,
+    val response: Response<*>?
+) : HttpException(response)


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/212

## What happened 👀

- Add `flowTransform` operator to map and handle custom errors logic (as `exceptions`) in `data` or `domain` layer to catch and pass the custom errors into the `app` module layer for other higher business implementations, instead of throwing a generic `Exception` to ViewModel.

## Insight 📝

- Build a custom `flowTransform {}` which basically inspired by `flow {}` operator.

## Proof Of Work 📹

Show us the implementation: screenshots, GIFs, etc.
