### PR TITLE
[#262] Update use case to use operator invoke function instead of old…

### DIFF
--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeComposeViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeComposeViewModel.kt
@@ -24,7 +24,7 @@ class HomeComposeViewModel @Inject constructor(
     init {
         execute {
             showLoading()
-            useCase.execute()
+            useCase()
                 .catch {
                     val errorMessage = it.message.orEmpty()
                     _error.emit(errorMessage)

--- a/sample-compose/domain/src/main/java/co/nimblehq/sample/compose/domain/usecase/UseCase.kt
+++ b/sample-compose/domain/src/main/java/co/nimblehq/sample/compose/domain/usecase/UseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 
 class UseCase @Inject constructor(private val repository: Repository) {
 
-    fun execute(): Flow<List<Model>> {
+    operator fun invoke(): Flow<List<Model>> {
         return repository.getModels()
     }
 }

--- a/sample-compose/domain/src/test/java/co/nimblehq/sample/compose/domain/usecase/UseCaseTest.kt
+++ b/sample-compose/domain/src/test/java/co/nimblehq/sample/compose/domain/usecase/UseCaseTest.kt
@@ -29,7 +29,7 @@ class UseCaseTest {
         val expected = listOf(model)
         every { mockRepository.getModels() } returns flowOf(expected)
 
-        useCase.execute().collect {
+        useCase().collect {
             it shouldBe expected
         }
     }
@@ -39,7 +39,7 @@ class UseCaseTest {
         val expected = Exception()
         every { mockRepository.getModels() } returns flow { throw expected }
 
-        useCase.execute().catch {
+        useCase().catch {
             it shouldBe expected
         }.collect()
     }

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/home/HomeViewModel.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/home/HomeViewModel.kt
@@ -23,7 +23,7 @@ class HomeViewModel @Inject constructor(
     init {
         execute {
             showLoading()
-            useCase.execute()
+            useCase()
                 .catch {
                     val errorMessage = it.message.orEmpty()
                     _error.emit(errorMessage)

--- a/sample-xml/domain/src/main/java/co/nimblehq/sample/xml/domain/usecase/UseCase.kt
+++ b/sample-xml/domain/src/main/java/co/nimblehq/sample/xml/domain/usecase/UseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 
 class UseCase @Inject constructor(private val repository: Repository) {
 
-    fun execute(): Flow<List<Model>> {
+    operator fun invoke(): Flow<List<Model>> {
         return repository.getModels()
     }
 }

--- a/sample-xml/domain/src/test/java/co/nimblehq/sample/xml/domain/usecase/UseCaseTest.kt
+++ b/sample-xml/domain/src/test/java/co/nimblehq/sample/xml/domain/usecase/UseCaseTest.kt
@@ -30,7 +30,7 @@ class UseCaseTest {
         val expected = listOf(model)
         every { mockRepository.getModels() } returns flowOf(expected)
 
-        useCase.execute().collect {
+        useCase().collect {
             it shouldBe expected
         }
     }
@@ -40,7 +40,7 @@ class UseCaseTest {
         val expected = Exception()
         every { mockRepository.getModels() } returns flow { throw expected }
 
-        useCase.execute().catch {
+        useCase().catch {
             it shouldBe expected
         }.collect()
     }

--- a/template/app/src/main/java/co/nimblehq/template/ui/screens/compose/HomeComposeViewModel.kt
+++ b/template/app/src/main/java/co/nimblehq/template/ui/screens/compose/HomeComposeViewModel.kt
@@ -22,7 +22,7 @@ class HomeComposeViewModel @Inject constructor(
     init {
         execute {
             showLoading()
-            useCase.execute()
+            useCase()
                 .catch {
                     _error.emit(it)
                 }

--- a/template/app/src/main/java/co/nimblehq/template/ui/screens/xml/HomeViewModel.kt
+++ b/template/app/src/main/java/co/nimblehq/template/ui/screens/xml/HomeViewModel.kt
@@ -22,7 +22,7 @@ class HomeViewModel @Inject constructor(
     init {
         execute {
             showLoading()
-            useCase.execute()
+            useCase()
                 .catch {
                     _error.emit(it)
                 }

--- a/template/domain/src/main/java/co/nimblehq/template/domain/usecase/UseCase.kt
+++ b/template/domain/src/main/java/co/nimblehq/template/domain/usecase/UseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 
 class UseCase @Inject constructor(private val repository: Repository) {
 
-    fun execute(): Flow<List<Model>> {
+    operator fun invoke(): Flow<List<Model>> {
         return repository.getModels()
     }
 }

--- a/template/domain/src/test/java/co/nimblehq/template/domain/usecase/UseCaseTest.kt
+++ b/template/domain/src/test/java/co/nimblehq/template/domain/usecase/UseCaseTest.kt
@@ -29,7 +29,7 @@ class UseCaseTest {
         val expected = listOf(model)
         every { mockRepository.getModels() } returns flowOf(expected)
 
-        useCase.execute().collect {
+        useCase().collect {
             it shouldBe expected
         }
     }
@@ -39,7 +39,7 @@ class UseCaseTest {
         val expected = Exception()
         every { mockRepository.getModels() } returns flow { throw expected }
 
-        useCase.execute().catch {
+        useCase().catch {
             it shouldBe expected
         }.collect()
     }


### PR DESCRIPTION
Closes #262 

## What happened 👀

In Kotlin we can [override the invoke method](https://riptutorial.com/kotlin/example/31101/overriding-invoke-method-to-build-dsl). 

With this approach, we can eliminate `.execute()` and use the invoke function instead

---

Ex:

If we add this to our use case:
```
interface DoSomethingUseCase {
    suspend operator fun invoke(id: String)
}
```

Then we can call the use case without `.execute()`:
```
DoSomethingUseCase(id)
```

## Insight 📝

- Refactor `UseCase` classes to use `operator fun invoke()` instead of `fun execute()`
- Refactor classes which calls `execute()`

## Proof Of Work 📹


https://user-images.githubusercontent.com/32578035/195009412-a9a840f6-bcb8-4378-a53c-cb29e23087f7.mp4


