### PR TITLE
[#307] Update README for more clear about where should run the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Our Android template: **[template](https://github.com/nimblehq/android-templates
 
 1. Clone or download this repository to your local machine, then extract and open the folder
 2. Install [Kscript](https://github.com/holgerbrandl/kscript#installation)
-3. Run `kscript new_project.kts` to create a new project with the following arguments:
+3. Run `cd scripts` to get into the scripts directory
+4. Run `kscript new_project.kts` to create a new project with the following arguments:
   ```   
     package-name=                      New package name (i.e., com.example.package)
     app-name=                          New app name (i.e., MyApp, "My App", "my-app")
@@ -23,7 +24,7 @@ Our Android template: **[template](https://github.com/nimblehq/android-templates
 
   Example: `kscript new_project.kts package-name=co.myproject.example app-name="My Project"`
 
-4. Update `android_version_code` and `android_version_name` in `template/build.gradle`
+5. Update `android_version_code` and `android_version_name` in `template/build.gradle`
 
 ## Wiki
 


### PR DESCRIPTION
Resolved https://github.com/nimblehq/android-templates/issues/307

## What happened 👀

Update README to be more clear about where should run the script to generate the new project.

## Insight 📝

I have 3 options:
1. To tell the consumer to run `cd` command first.
2. To tell the consumer to run the script inside of the `scripts` directory as a remark after describing
    > Run `kscript new_project.kts` to create a new project with the following arguments:
3. Update the `kscript new_project.kts` to `kscript scripts/new_project.kts`

I prefer the **option 1** since it's simpler and don't make the command to be too long in case we will have many more options in the script in the future.

## Proof Of Work 📹

<img width="890" alt="Screen Shot 2565-10-24 at 11 18 28 AM" src="https://user-images.githubusercontent.com/12026942/197447776-da3a157b-7074-4213-8f2c-245eb5c57499.png">

