### PR TITLE
[#163][#191][#300] Upgrade JDK, SDK, Gradle & Kotlin for Sample

### DIFF
--- a/.cicdtemplate/.github/workflows/deploy_staging_and_production_to_firebase_app_distribution.yml
+++ b/.cicdtemplate/.github/workflows/deploy_staging_and_production_to_firebase_app_distribution.yml
@@ -13,10 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Set up timezone
         uses: zcong1993/setup-timezone@master

--- a/.cicdtemplate/.github/workflows/review_pull_request.yml
+++ b/.cicdtemplate/.github/workflows/review_pull_request.yml
@@ -10,10 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Checkout source code
         uses: actions/checkout@v2.3.2

--- a/.cicdtemplate/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.cicdtemplate/.github/workflows/run_detekt_and_unit_tests.yml
@@ -16,10 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Set up timezone
         uses: zcong1993/setup-timezone@master

--- a/gradle-wrapper.properties
+++ b/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/sample-compose/app/build.gradle.kts
+++ b/sample-compose/app/build.gradle.kts
@@ -132,6 +132,7 @@ dependencies {
     implementation("androidx.compose.foundation:foundation:${Versions.COMPOSE_VERSION}")
     implementation("androidx.compose.material:material:${Versions.COMPOSE_VERSION}")
 
+    implementation("androidx.fragment:fragment-ktx:${Versions.ANDROIDX_FRAGMENT_KTX_VERSION}")
     implementation("androidx.navigation:navigation-fragment-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")
     implementation("androidx.navigation:navigation-runtime-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")
     implementation("androidx.navigation:navigation-ui-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")

--- a/sample-compose/app/build.gradle.kts
+++ b/sample-compose/app/build.gradle.kts
@@ -72,12 +72,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     composeOptions {

--- a/sample-compose/app/build.gradle.kts
+++ b/sample-compose/app/build.gradle.kts
@@ -82,7 +82,7 @@ android {
 
     composeOptions {
         kotlinCompilerVersion = Versions.KOTLIN_VERSION
-        kotlinCompilerExtensionVersion = Versions.COMPOSE_VERSION
+        kotlinCompilerExtensionVersion = Versions.COMPOSE_COMPILER_VERSION
     }
 
     buildFeatures {

--- a/sample-compose/app/build.gradle.kts
+++ b/sample-compose/app/build.gradle.kts
@@ -157,7 +157,7 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-core:${Versions.TEST_KOTEST_VERSION}")
     testImplementation("junit:junit:${Versions.TEST_JUNIT_VERSION}")
     testImplementation("org.robolectric:robolectric:${Versions.TEST_ROBOLECTRIC_VERSION}")
-    testImplementation("androidx.test:core:${Versions.ANDROIDX_CORE_KTX_VERSION}")
+    testImplementation("androidx.test:core:${Versions.ANDROIDX_TEST_CORE_VERSION}")
     testImplementation("androidx.test:runner:${Versions.TEST_RUNNER_VERSION}")
     testImplementation("androidx.test:rules:${Versions.TEST_RUNNER_VERSION}")
     testImplementation("androidx.test.ext:junit-ktx:${Versions.TEST_JUNIT_ANDROIDX_EXT_VERSION}")

--- a/sample-compose/app/src/main/AndroidManifest.xml
+++ b/sample-compose/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <activity android:name=".ui.screens.MainActivity">
+        <activity android:name=".ui.screens.MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/extension/ViewModelExt.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/extension/ViewModelExt.kt
@@ -3,9 +3,9 @@ package co.nimblehq.sample.compose.extension
 import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
 import androidx.annotation.MainThread
-import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.*
 import androidx.lifecycle.*
+import androidx.lifecycle.viewmodel.CreationExtras
 
 /**
  * PLEASE READ THIS BEFORE IMPLEMENT:

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/extension/ViewModelExt.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/extension/ViewModelExt.kt
@@ -17,15 +17,23 @@ import androidx.lifecycle.*
  * Reference: https://proandroiddev.com/testing-the-untestable-the-case-of-the-viewmodel-delegate-975c09160993
  */
 @MainThread
+inline fun <reified VM : ViewModel> Fragment.provideActivityViewModels(
+    noinline extrasProducer: (() -> CreationExtras)? = null,
+    noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
+): Lazy<VM> = OverridableLazy(activityViewModels(extrasProducer, factoryProducer))
+
+@MainThread
 inline fun <reified VM : ViewModel> Fragment.provideViewModels(
     noinline ownerProducer: () -> ViewModelStoreOwner = { this },
+    noinline extrasProducer: (() -> CreationExtras)? = null,
     noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
-): Lazy<VM> = OverridableLazy(viewModels(ownerProducer, factoryProducer))
+): Lazy<VM> = OverridableLazy(viewModels(ownerProducer, extrasProducer, factoryProducer))
 
 @MainThread
 inline fun <reified VM : ViewModel> ComponentActivity.provideViewModels(
+    noinline extrasProducer: (() -> CreationExtras)? = null,
     noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
-): Lazy<VM> = OverridableLazy(viewModels(factoryProducer))
+): Lazy<VM> = OverridableLazy(viewModels(extrasProducer, factoryProducer))
 
 class OverridableLazy<T>(var implementation: Lazy<T>) : Lazy<T> {
 

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -32,7 +32,15 @@ tasks.register("clean", Delete::class) {
 
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
     // Target version of the generated JVM bytecode. It is used for type resolution.
-    jvmTarget = JavaVersion.VERSION_1_8.toString()
+    jvmTarget = JavaVersion.VERSION_11.toString()
+    reports {
+        xml {
+            outputLocation.set(file("build/reports/detekt/detekt.xml"))
+        }
+        html {
+            outputLocation.set(file("build/reports/detekt/detekt.html"))
+        }
+    }
 }
 
 detekt {
@@ -55,16 +63,6 @@ detekt {
     ignoredBuildTypes = listOf("release")
     ignoredFlavors = listOf("production")
 
-    reports {
-        xml {
-            enabled = true
-            destination = file("build/reports/detekt.xml")
-        }
-        html {
-            enabled = true
-            destination = file("build/reports/detekt.html")
-        }
-    }
 }
 
 koverMerged {

--- a/sample-compose/buildSrc/src/main/java/Versions.kt
+++ b/sample-compose/buildSrc/src/main/java/Versions.kt
@@ -21,7 +21,7 @@ object Versions {
     const val ANDROIDX_SUPPORT_VERSION = "1.5.1"
 
     const val CHUCKER_VERSION = "3.5.2"
-    const val COMPOSE_VERSION = "1.3.1"
+    const val COMPOSE_VERSION = "1.2.1"
     const val COMPOSE_COMPILER_VERSION = "1.3.2"
 
     const val HILT_VERSION = "2.44"

--- a/sample-compose/buildSrc/src/main/java/Versions.kt
+++ b/sample-compose/buildSrc/src/main/java/Versions.kt
@@ -1,9 +1,9 @@
 object Versions {
-    const val BUILD_GRADLE_VERSION = "4.2.1"
+    const val BUILD_GRADLE_VERSION = "7.3.0"
 
-    const val ANDROID_COMPILE_SDK_VERSION = 30
-    const val ANDROID_MIN_SDK_VERSION = 23
-    const val ANDROID_TARGET_SDK_VERSION = 30
+    const val ANDROID_COMPILE_SDK_VERSION = 33
+    const val ANDROID_MIN_SDK_VERSION = 24
+    const val ANDROID_TARGET_SDK_VERSION = 33
 
     const val ANDROID_VERSION_CODE = 1
     const val ANDROID_VERSION_NAME = "3.14.0"
@@ -11,23 +11,26 @@ object Versions {
     // Dependencies (Alphabet sorted)
     const val ANDROID_COMMON_KTX_VERSION = "0.1.1"
     const val ANDROID_CRYPTO_VERSION = "1.0.0"
-    const val ANDROIDX_ACTIVITY_KTX_VERSION = "1.2.1"
-    const val ANDROIDX_CORE_KTX_VERSION = "1.3.0"
-    const val ANDROIDX_FRAGMENT_VERSION = "1.3.3"
-    const val ANDROIDX_LIFECYCLE_VERSION = "2.4.0-alpha02"
+    const val ANDROIDX_ACTIVITY_KTX_VERSION = "1.6.0"
+    const val ANDROIDX_CORE_KTX_VERSION = "1.9.0"
+    const val ANDROIDX_TEST_CORE_VERSION = "1.4.0"
+    const val ANDROIDX_FRAGMENT_VERSION = "1.4.0"
+    const val ANDROIDX_FRAGMENT_KTX_VERSION = "1.5.3"
+    const val ANDROIDX_LIFECYCLE_VERSION = "2.5.1"
     const val ANDROIDX_NAVIGATION_VERSION = "2.3.4"
-    const val ANDROIDX_SUPPORT_VERSION = "1.3.0"
+    const val ANDROIDX_SUPPORT_VERSION = "1.5.1"
 
     const val CHUCKER_VERSION = "3.5.2"
-    const val COMPOSE_VERSION = "1.0.2"
+    const val COMPOSE_VERSION = "1.2.1"
+    const val COMPOSE_COMPILER_VERSION = "1.3.2"
 
-    const val HILT_VERSION = "2.38.1"
+    const val HILT_VERSION = "2.44"
 
     const val JAVAX_INJECT_VERSION = "1"
 
-    const val KOTLIN_REFLECT_VERSION = "1.5.10"
-    const val KOTLIN_VERSION = "1.5.21"
-    const val KOTLINX_COROUTINES_VERSION = "1.5.0"
+    const val KOTLIN_REFLECT_VERSION = "1.7.20"
+    const val KOTLIN_VERSION = "1.7.20"
+    const val KOTLINX_COROUTINES_VERSION = "1.6.4"
     const val KOVER_VERSION = "0.6.0"
 
     const val MOSHI_VERSION = "1.12.0"
@@ -41,7 +44,7 @@ object Versions {
     const val TIMBER_LOG_VERSION = "4.7.1"
 
     // Configuration
-    const val DETEKT_VERSION = "1.20.0"
+    const val DETEKT_VERSION = "1.21.0"
 
     // Testing libraries
     const val TEST_JUNIT_ANDROIDX_EXT_VERSION = "1.1.2"
@@ -49,5 +52,5 @@ object Versions {
     const val TEST_KOTEST_VERSION = "4.6.3"
     const val TEST_MOCKK_VERSION = "1.10.6"
     const val TEST_ROBOLECTRIC_VERSION = "4.8.2"
-    const val TEST_RUNNER_VERSION = "1.3.0"
+    const val TEST_RUNNER_VERSION = "1.4.0"
 }

--- a/sample-compose/buildSrc/src/main/java/Versions.kt
+++ b/sample-compose/buildSrc/src/main/java/Versions.kt
@@ -21,7 +21,7 @@ object Versions {
     const val ANDROIDX_SUPPORT_VERSION = "1.5.1"
 
     const val CHUCKER_VERSION = "3.5.2"
-    const val COMPOSE_VERSION = "1.2.1"
+    const val COMPOSE_VERSION = "1.3.1"
     const val COMPOSE_COMPILER_VERSION = "1.3.2"
 
     const val HILT_VERSION = "2.44"

--- a/sample-compose/data/build.gradle.kts
+++ b/sample-compose/data/build.gradle.kts
@@ -31,12 +31,12 @@ android {
     }
 
     compileOptions {
-        targetCompatibility = JavaVersion.VERSION_1_8
-        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     lintOptions {

--- a/sample-compose/data/build.gradle.kts
+++ b/sample-compose/data/build.gradle.kts
@@ -10,8 +10,6 @@ android {
     defaultConfig {
         minSdk = Versions.ANDROID_MIN_SDK_VERSION
         targetSdk = Versions.ANDROID_TARGET_SDK_VERSION
-        versionCode = Versions.ANDROID_VERSION_CODE
-        versionName = Versions.ANDROID_VERSION_NAME
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/sample-compose/data/src/test/java/co/nimblehq/sample/compose/data/extensions/ResponseMappingTest.kt
+++ b/sample-compose/data/src/test/java/co/nimblehq/sample/compose/data/extensions/ResponseMappingTest.kt
@@ -9,7 +9,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.io.IOException
 import java.io.InterruptedIOException
@@ -20,7 +20,7 @@ class ResponseMappingTest {
 
     @Test
     fun `When mapping API request flow failed with UnknownHostException, it returns mapped NoConnectivityException error`() =
-        runBlockingTest {
+        runTest {
             flowTransform<Model> {
                 throw UnknownHostException()
             }.catch {
@@ -30,7 +30,7 @@ class ResponseMappingTest {
 
     @Test
     fun `When mapping API request flow failed with InterruptedIOException, it returns mapped NoConnectivityException error`() =
-        runBlockingTest {
+        runTest {
             flowTransform<Model> {
                 throw InterruptedIOException()
             }.catch {
@@ -40,7 +40,7 @@ class ResponseMappingTest {
 
     @Test
     fun `When mapping API request flow failed with HttpException, it returns mapped ApiException error`() =
-        runBlockingTest {
+        runTest {
             val httpException = MockUtil.mockHttpException
             flowTransform<Model> {
                 throw httpException
@@ -55,7 +55,7 @@ class ResponseMappingTest {
 
     @Test
     fun `When mapping API request flow failed with unhandled exceptions, it should throw that error`() =
-        runBlockingTest {
+        runTest {
             val exception = IOException("Canceled")
             flowTransform<Model> {
                 throw exception

--- a/sample-compose/data/src/test/java/co/nimblehq/sample/compose/data/repository/RepositoryTest.kt
+++ b/sample-compose/data/src/test/java/co/nimblehq/sample/compose/data/repository/RepositoryTest.kt
@@ -10,9 +10,9 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Before
 import org.junit.Test
+import kotlinx.coroutines.test.runTest
 
 @ExperimentalCoroutinesApi
 class RepositoryTest {
@@ -29,7 +29,7 @@ class RepositoryTest {
     }
 
     @Test
-    fun `When request successful, it returns success`() = runBlockingTest {
+    fun `When request successful, it returns success`() = runTest {
         val expected = listOf(response)
         coEvery { mockService.getResponses() } returns expected
 
@@ -39,7 +39,7 @@ class RepositoryTest {
     }
 
     @Test
-    fun `When request failed, it returns error`() = runBlockingTest {
+    fun `When request failed, it returns error`() = runTest {
         val expected = Throwable()
         coEvery { mockService.getResponses() } throws expected
 

--- a/sample-compose/domain/build.gradle.kts
+++ b/sample-compose/domain/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 dependencies {

--- a/sample-compose/domain/src/test/java/co/nimblehq/sample/compose/domain/usecase/UseCaseTest.kt
+++ b/sample-compose/domain/src/test/java/co/nimblehq/sample/compose/domain/usecase/UseCaseTest.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
@@ -25,7 +25,7 @@ class UseCaseTest {
     }
 
     @Test
-    fun `When request successful, it returns success`() = runBlockingTest {
+    fun `When request successful, it returns success`() = runTest {
         val expected = listOf(model)
         every { mockRepository.getModels() } returns flowOf(expected)
 
@@ -35,7 +35,7 @@ class UseCaseTest {
     }
 
     @Test
-    fun `When request failed, it returns error`() = runBlockingTest {
+    fun `When request failed, it returns error`() = runTest {
         val expected = Exception()
         every { mockRepository.getModels() } returns flow { throw expected }
 

--- a/sample-compose/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-compose/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/sample-xml/app/build.gradle.kts
+++ b/sample-xml/app/build.gradle.kts
@@ -72,12 +72,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     buildFeatures {

--- a/sample-xml/app/build.gradle.kts
+++ b/sample-xml/app/build.gradle.kts
@@ -122,6 +122,7 @@ dependencies {
     implementation("androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX_VERSION}")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
 
+    implementation("androidx.fragment:fragment-ktx:${Versions.ANDROIDX_FRAGMENT_KTX_VERSION}")
     implementation("androidx.navigation:navigation-fragment-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")
     implementation("androidx.navigation:navigation-runtime-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")
     implementation("androidx.navigation:navigation-ui-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")

--- a/sample-xml/app/build.gradle.kts
+++ b/sample-xml/app/build.gradle.kts
@@ -149,7 +149,7 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-core:${Versions.TEST_KOTEST_VERSION}")
     testImplementation("junit:junit:${Versions.TEST_JUNIT_VERSION}")
     testImplementation("org.robolectric:robolectric:${Versions.TEST_ROBOLECTRIC_VERSION}")
-    testImplementation("androidx.test:core:${Versions.ANDROIDX_CORE_KTX_VERSION}")
+    testImplementation("androidx.test:core:${Versions.ANDROIDX_TEST_CORE_VERSION}")
     testImplementation("androidx.test:runner:${Versions.TEST_RUNNER_VERSION}")
     testImplementation("androidx.test:rules:${Versions.TEST_RUNNER_VERSION}")
     testImplementation("androidx.test.ext:junit-ktx:${Versions.TEST_JUNIT_ANDROIDX_EXT_VERSION}")

--- a/sample-xml/app/src/main/AndroidManifest.xml
+++ b/sample-xml/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <activity android:name=".ui.screens.MainActivity">
+        <activity android:name=".ui.screens.MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/extension/ViewModelExt.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/extension/ViewModelExt.kt
@@ -1,5 +1,7 @@
 package co.nimblehq.sample.xml.extension
 
+import androidx.activity.ComponentActivity
+import androidx.activity.viewModels
 import androidx.annotation.MainThread
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -7,6 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.CreationExtras
 
 /**
  * PLEASE READ THIS BEFORE IMPLEMENT:

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/extension/ViewModelExt.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/extension/ViewModelExt.kt
@@ -19,14 +19,22 @@ import androidx.lifecycle.ViewModelStoreOwner
  */
 @MainThread
 inline fun <reified VM : ViewModel> Fragment.provideActivityViewModels(
+    noinline extrasProducer: (() -> CreationExtras)? = null,
     noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
-): Lazy<VM> = OverridableLazy(activityViewModels(factoryProducer))
+): Lazy<VM> = OverridableLazy(activityViewModels(extrasProducer, factoryProducer))
 
 @MainThread
 inline fun <reified VM : ViewModel> Fragment.provideViewModels(
     noinline ownerProducer: () -> ViewModelStoreOwner = { this },
+    noinline extrasProducer: (() -> CreationExtras)? = null,
     noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
-): Lazy<VM> = OverridableLazy(viewModels(ownerProducer, factoryProducer))
+): Lazy<VM> = OverridableLazy(viewModels(ownerProducer, extrasProducer, factoryProducer))
+
+@MainThread
+inline fun <reified VM : ViewModel> ComponentActivity.provideViewModels(
+    noinline extrasProducer: (() -> CreationExtras)? = null,
+    noinline factoryProducer: (() -> ViewModelProvider.Factory)? = null
+): Lazy<VM> = OverridableLazy(viewModels(extrasProducer, factoryProducer))
 
 class OverridableLazy<T>(var implementation: Lazy<T>) : Lazy<T> {
 

--- a/sample-xml/build.gradle.kts
+++ b/sample-xml/build.gradle.kts
@@ -32,7 +32,15 @@ tasks.register("clean", Delete::class) {
 
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
     // Target version of the generated JVM bytecode. It is used for type resolution.
-    jvmTarget = JavaVersion.VERSION_1_8.toString()
+    jvmTarget = JavaVersion.VERSION_11.toString()
+    reports {
+        xml {
+            outputLocation.set(file("build/reports/detekt/detekt.xml"))
+        }
+        html {
+            outputLocation.set(file("build/reports/detekt/detekt.html"))
+        }
+    }
 }
 
 detekt {

--- a/sample-xml/build.gradle.kts
+++ b/sample-xml/build.gradle.kts
@@ -62,17 +62,6 @@ detekt {
 
     ignoredBuildTypes = listOf("release")
     ignoredFlavors = listOf("production")
-
-    reports {
-        xml {
-            enabled = true
-            destination = file("build/reports/detekt.xml")
-        }
-        html {
-            enabled = true
-            destination = file("build/reports/detekt.html")
-        }
-    }
 }
 
 koverMerged {

--- a/sample-xml/buildSrc/src/main/java/Versions.kt
+++ b/sample-xml/buildSrc/src/main/java/Versions.kt
@@ -21,7 +21,6 @@ object Versions {
     const val ANDROIDX_SUPPORT_VERSION = "1.5.1"
 
     const val CHUCKER_VERSION = "3.5.2"
-    const val COMPOSE_COMPILER_VERSION = "1.3.2"
     const val CONSTRAINT_LAYOUT_VERSION = "2.1.4"
 
     const val HILT_VERSION = "2.44"

--- a/sample-xml/buildSrc/src/main/java/Versions.kt
+++ b/sample-xml/buildSrc/src/main/java/Versions.kt
@@ -1,9 +1,9 @@
 object Versions {
-    const val BUILD_GRADLE_VERSION = "4.2.1"
+    const val BUILD_GRADLE_VERSION = "7.3.0"
 
-    const val ANDROID_COMPILE_SDK_VERSION = 30
-    const val ANDROID_MIN_SDK_VERSION = 23
-    const val ANDROID_TARGET_SDK_VERSION = 30
+    const val ANDROID_COMPILE_SDK_VERSION = 33
+    const val ANDROID_MIN_SDK_VERSION = 24
+    const val ANDROID_TARGET_SDK_VERSION = 33
 
     const val ANDROID_VERSION_CODE = 1
     const val ANDROID_VERSION_NAME = "3.14.0"
@@ -11,23 +11,26 @@ object Versions {
     // Dependencies (Alphabet sorted)
     const val ANDROID_COMMON_KTX_VERSION = "0.1.1"
     const val ANDROID_CRYPTO_VERSION = "1.0.0"
-    const val ANDROIDX_ACTIVITY_KTX_VERSION = "1.2.1"
-    const val ANDROIDX_CORE_KTX_VERSION = "1.3.0"
-    const val ANDROIDX_FRAGMENT_VERSION = "1.3.3"
-    const val ANDROIDX_LIFECYCLE_VERSION = "2.4.0-alpha02"
+    const val ANDROIDX_ACTIVITY_KTX_VERSION = "1.6.0"
+    const val ANDROIDX_CORE_KTX_VERSION = "1.9.0"
+    const val ANDROIDX_TEST_CORE_VERSION = "1.4.0"
+    const val ANDROIDX_FRAGMENT_VERSION = "1.4.0"
+    const val ANDROIDX_FRAGMENT_KTX_VERSION = "1.5.3"
+    const val ANDROIDX_LIFECYCLE_VERSION = "2.5.1"
     const val ANDROIDX_NAVIGATION_VERSION = "2.3.4"
-    const val ANDROIDX_SUPPORT_VERSION = "1.3.0"
+    const val ANDROIDX_SUPPORT_VERSION = "1.5.1"
 
     const val CHUCKER_VERSION = "3.5.2"
-    const val CONSTRAINT_LAYOUT_VERSION = "2.0.0-alpha3"
+    const val COMPOSE_COMPILER_VERSION = "1.3.2"
+    const val CONSTRAINT_LAYOUT_VERSION = "2.1.4"
 
-    const val HILT_VERSION = "2.38.1"
+    const val HILT_VERSION = "2.44"
 
     const val JAVAX_INJECT_VERSION = "1"
 
-    const val KOTLIN_REFLECT_VERSION = "1.5.10"
-    const val KOTLIN_VERSION = "1.5.21"
-    const val KOTLINX_COROUTINES_VERSION = "1.5.0"
+    const val KOTLIN_REFLECT_VERSION = "1.7.20"
+    const val KOTLIN_VERSION = "1.7.20"
+    const val KOTLINX_COROUTINES_VERSION = "1.6.4"
     const val KOVER_VERSION = "0.6.0"
 
     const val MOSHI_VERSION = "1.12.0"
@@ -41,7 +44,7 @@ object Versions {
     const val TIMBER_LOG_VERSION = "4.7.1"
 
     // Configuration
-    const val DETEKT_VERSION = "1.20.0"
+    const val DETEKT_VERSION = "1.21.0"
 
     // Testing libraries
     const val TEST_JUNIT_ANDROIDX_EXT_VERSION = "1.1.2"
@@ -49,5 +52,5 @@ object Versions {
     const val TEST_KOTEST_VERSION = "4.6.3"
     const val TEST_MOCKK_VERSION = "1.10.6"
     const val TEST_ROBOLECTRIC_VERSION = "4.8.2"
-    const val TEST_RUNNER_VERSION = "1.3.0"
+    const val TEST_RUNNER_VERSION = "1.4.0"
 }

--- a/sample-xml/data/build.gradle.kts
+++ b/sample-xml/data/build.gradle.kts
@@ -31,12 +31,12 @@ android {
     }
 
     compileOptions {
-        targetCompatibility = JavaVersion.VERSION_1_8
-        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     lintOptions {

--- a/sample-xml/data/build.gradle.kts
+++ b/sample-xml/data/build.gradle.kts
@@ -10,8 +10,6 @@ android {
     defaultConfig {
         minSdk = Versions.ANDROID_MIN_SDK_VERSION
         targetSdk = Versions.ANDROID_TARGET_SDK_VERSION
-        versionCode = Versions.ANDROID_VERSION_CODE
-        versionName = Versions.ANDROID_VERSION_NAME
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/sample-xml/data/src/test/java/co/nimblehq/sample/xml/data/extensions/ResponseMappingTest.kt
+++ b/sample-xml/data/src/test/java/co/nimblehq/sample/xml/data/extensions/ResponseMappingTest.kt
@@ -9,7 +9,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.io.IOException
 import java.io.InterruptedIOException
@@ -20,7 +20,7 @@ class ResponseMappingTest {
 
     @Test
     fun `When mapping API request flow failed with UnknownHostException, it returns mapped NoConnectivityException error`() =
-        runBlockingTest {
+        runTest {
             flowTransform<Model> {
                 throw UnknownHostException()
             }.catch {
@@ -30,7 +30,7 @@ class ResponseMappingTest {
 
     @Test
     fun `When mapping API request flow failed with InterruptedIOException, it returns mapped NoConnectivityException error`() =
-        runBlockingTest {
+        runTest {
             flowTransform<Model> {
                 throw InterruptedIOException()
             }.catch {
@@ -40,7 +40,7 @@ class ResponseMappingTest {
 
     @Test
     fun `When mapping API request flow failed with HttpException, it returns mapped ApiException error`() =
-        runBlockingTest {
+        runTest {
             val httpException = MockUtil.mockHttpException
             flowTransform<Model> {
                 throw httpException
@@ -55,7 +55,7 @@ class ResponseMappingTest {
 
     @Test
     fun `When mapping API request flow failed with unhandled exceptions, it should throw that error`() =
-        runBlockingTest {
+        runTest {
             val exception = IOException("Canceled")
             flowTransform<Model> {
                 throw exception

--- a/sample-xml/data/src/test/java/co/nimblehq/sample/xml/data/repository/RepositoryTest.kt
+++ b/sample-xml/data/src/test/java/co/nimblehq/sample/xml/data/repository/RepositoryTest.kt
@@ -10,7 +10,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
@@ -29,7 +29,7 @@ class RepositoryTest {
     }
 
     @Test
-    fun `When request successful, it returns success`() = runBlockingTest {
+    fun `When request successful, it returns success`() = runTest {
         val expected = listOf(response)
         coEvery { mockService.getResponses() } returns expected
 
@@ -39,7 +39,7 @@ class RepositoryTest {
     }
 
     @Test
-    fun `When request failed, it returns error`() = runBlockingTest {
+    fun `When request failed, it returns error`() = runTest {
         val expected = Throwable()
         coEvery { mockService.getResponses() } throws expected
 

--- a/sample-xml/domain/build.gradle.kts
+++ b/sample-xml/domain/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 dependencies {

--- a/sample-xml/domain/src/test/java/co/nimblehq/sample/xml/domain/usecase/UseCaseTest.kt
+++ b/sample-xml/domain/src/test/java/co/nimblehq/sample/xml/domain/usecase/UseCaseTest.kt
@@ -7,7 +7,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
@@ -26,7 +26,7 @@ class UseCaseTest {
     }
 
     @Test
-    fun `When request successful, it returns success`() = runBlockingTest {
+    fun `When request successful, it returns success`() = runTest {
         val expected = listOf(model)
         every { mockRepository.getModels() } returns flowOf(expected)
 
@@ -36,7 +36,7 @@ class UseCaseTest {
     }
 
     @Test
-    fun `When request failed, it returns error`() = runBlockingTest {
+    fun `When request failed, it returns error`() = runTest {
         val expected = Exception()
         every { mockRepository.getModels() } returns flow { throw expected }
 

--- a/sample-xml/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-xml/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/163
https://github.com/nimblehq/android-templates/issues/191
https://github.com/nimblehq/android-templates/issues/300

## What happened 👀

- Java 1.8 is old, we should upgrade it to 11 in order to use latest Gradle or Kotlin version
- Upgrade Compile and Target SDK version from 30 to 33
- Update Gradle to version 7+

## Insight 📝

For XML and Compose sample:
- Upgrade JDK 11 for CI Pull Request Review and Run Detekt/Unit Test
- Upgrade Gradle to 7.3.0
- Upgrade min Android from 23 -> 24
- Upgrade Java from 8 to 11

## Proof Of Work 📹

N/A
