### PR TITLE
[#346] Fix failing sample xml test

### DIFF
--- a/sample-compose/buildSrc/src/main/java/Versions.kt
+++ b/sample-compose/buildSrc/src/main/java/Versions.kt
@@ -48,6 +48,6 @@ object Versions {
     const val TEST_JUNIT_VERSION = "4.13.2"
     const val TEST_KOTEST_VERSION = "4.6.3"
     const val TEST_MOCKK_VERSION = "1.10.6"
-    const val TEST_ROBOLECTRIC_VERSION = "4.3.1"
+    const val TEST_ROBOLECTRIC_VERSION = "4.8.2"
     const val TEST_RUNNER_VERSION = "1.3.0"
 }

--- a/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
+++ b/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
@@ -1,6 +1,6 @@
 package co.nimblehq.sample.xml.ui.screens.xml
 
-import co.nimblehq.sample.xml.R
+import androidx.core.view.isVisible
 import co.nimblehq.sample.xml.databinding.FragmentHomeBinding
 import co.nimblehq.sample.xml.test.TestNavigatorModule.mockMainNavigator
 import co.nimblehq.sample.xml.test.getPrivateProperty
@@ -9,8 +9,8 @@ import co.nimblehq.sample.xml.ui.BaseFragmentTest
 import co.nimblehq.sample.xml.ui.screens.home.HomeFragment
 import co.nimblehq.sample.xml.ui.screens.home.HomeViewModel
 import dagger.hilt.android.testing.*
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import org.junit.*
 
@@ -28,9 +28,9 @@ class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
     }
 
     @Test
-    fun `When initializing fragment, it displays the title correctly`() {
+    fun `When initializing fragment, it displays the recycler view`() {
         launchFragment()
-        fragment.binding.tvTitle.text.toString() shouldBe fragment.resources.getString(R.string.app_name)
+        fragment.binding.rvHome.isVisible.shouldBeTrue()
     }
 
     private fun launchFragment() {

--- a/sample-xml/buildSrc/src/main/java/Versions.kt
+++ b/sample-xml/buildSrc/src/main/java/Versions.kt
@@ -48,6 +48,6 @@ object Versions {
     const val TEST_JUNIT_VERSION = "4.13.2"
     const val TEST_KOTEST_VERSION = "4.6.3"
     const val TEST_MOCKK_VERSION = "1.10.6"
-    const val TEST_ROBOLECTRIC_VERSION = "4.3.1"
+    const val TEST_ROBOLECTRIC_VERSION = "4.8.2"
     const val TEST_RUNNER_VERSION = "1.3.0"
 }


### PR DESCRIPTION
Closes #346 

## What happened 👀

- Fix failing `HomeFragmentTest.kt` in `sample-xml`
- Update robolectrics versions for sample projects so it aligned with `template`

## Proof Of Work 📹

<img width="1424" alt="Screen Shot 2022-11-14 at 11 20 23" src="https://user-images.githubusercontent.com/18277915/201574470-2152f9e3-cf06-43bf-957c-440931b85bf9.png">
