### PR TITLE
[#336] [#338] Update new_project.kts to choose between XML or Compose and update documentation

### DIFF
--- a/.github/wiki/Home.md
+++ b/.github/wiki/Home.md
@@ -2,7 +2,7 @@ Welcome to the android-templates wiki!
 
 This repository generates a new project based on our preferences, by running a simple script. 
 
-Example: `kscript new_project.kts package-name=co.myproject.example app-name="My Project"`
+Example: `kscript new_project.kts package-name=co.myproject.example app-name="My Project" template=xml`
 
 This script must include all essentials by default, while optional features can be appended with flags. To prevent this repository from becoming a dumping playground, features can be rejected too.
 

--- a/.github/wiki/Home.md
+++ b/.github/wiki/Home.md
@@ -2,7 +2,7 @@ Welcome to the android-templates wiki!
 
 This repository generates a new project based on our preferences, by running a simple script. 
 
-Example: `kscript new_project.kts package-name=co.myproject.example app-name="My Project" template=xml`
+Example: `kscript new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml`
 
 This script must include all essentials by default, while optional features can be appended with flags. To prevent this repository from becoming a dumping playground, features can be rejected too.
 

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -42,4 +42,6 @@ jobs:
 
       - name: Verify generating new project from template
         working-directory: scripts
-        run: kscript new_project.kts package-name=co.myproject.example app-name="My Project"
+        run: |
+        kscript new_project.kts package-name=co.myproject.example app-name="My Project" template=xml
+        kscript new_project.kts package-name=co.myprojectcompose.example app-name="My Project Compose" template=compose

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -42,9 +42,9 @@ jobs:
 
       - name: Verify generating new project from template-xml
         working-directory: scripts
-        run: kscript new_project.kts package-name=co.myproject.example app-name="My Project" template=xml
+        run: kscript new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml
 
       - name: Verify generating new project from template-compose
         working-directory: scripts
-        run: kscript new_project.kts package-name=co.myprojectcompose.example app-name="My Project Compose" template=compose
+        run: kscript new_project.kts package-name=co.mycomposeproject.example app-name="My Compose Project" template=compose
 

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -40,8 +40,11 @@ jobs:
           sdk install kscript $kscriptVersion
           echo $PATH >> $GITHUB_PATH
 
-      - name: Verify generating new project from template
+      - name: Verify generating new project from template-xml
         working-directory: scripts
-        run: |
-        kscript new_project.kts package-name=co.myproject.example app-name="My Project" template=xml
-        kscript new_project.kts package-name=co.myprojectcompose.example app-name="My Project Compose" template=compose
+        run: kscript new_project.kts package-name=co.myproject.example app-name="My Project" template=xml
+
+      - name: Verify generating new project from template-compose
+        working-directory: scripts
+        run: kscript new_project.kts package-name=co.myprojectcompose.example app-name="My Project Compose" template=compose
+

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A collection of our Android templates:
 
   Examples: 
     `kscript new_project.kts package-name=co.myproject.example app-name="My Project" template=xml`
-    `scripts/new_project.kts new_project.kts package-name=co.myproject.example app-name="My Project" template=xml`
+    `kscript scripts/new_project.kts new_project.kts package-name=co.myproject.example app-name="My Project" template=xml`
 
 4. Update `android_version_code` and `android_version_name` in `template/build.gradle`
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ A collection of our Android templates:
   ```   
     package-name=                      New package name (i.e., com.example.package)
     app-name=                          New app name (i.e., MyApp, "My App", "my-app")
-    template=                          Template type (i.e., xml, compose)
+    template=                          Template (i.e., xml, compose)
   ```
 
   Examples: 
-    `kscript new_project.kts package-name=co.myproject.example app-name="My Project" template=xml`
-    `kscript scripts/new_project.kts new_project.kts package-name=co.myproject.example app-name="My Project" template=xml`
+    `kscript new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml`
+    `kscript scripts/new_project.kts new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml`
 
 4. Update `android_version_code` and `android_version_name` in `template/build.gradle`
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ A collection of our Android templates:
   ```   
     package-name=                      New package name (i.e., com.example.package)
     app-name=                          New app name (i.e., MyApp, "My App", "my-app")
+    template=                          Template type (i.e., xml, compose)
   ```
 
-  Example: `kscript new_project.kts package-name=co.myproject.example app-name="My Project"`
+  Examples: 
+    `kscript new_project.kts package-name=co.myproject.example app-name="My Project" template=xml`
+    `scripts/new_project.kts new_project.kts package-name=co.myproject.example app-name="My Project" template=xml`
 
 4. Update `android_version_code` and `android_version_name` in `template/build.gradle`
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A collection of our Android templates:
 
   Examples: 
     `kscript new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml`
-    `kscript scripts/new_project.kts new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml`
+    `kscript scripts/new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml`
 
 4. Update `android_version_code` and `android_version_name` in `template/build.gradle`
 

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -26,8 +26,8 @@ object NewProject {
     private const val TEMPLATE_APPLICATION_CLASS_NAME_COMPOSE = "TemplateComposeApplication"
     private const val TEMPLATE_PACKAGE_NAME_XML = "co.nimblehq.template.xml"
     private const val TEMPLATE_PACKAGE_NAME_COMPOSE = "co.nimblehq.template.compose"
-    private const val TEMPLATE_TYPE_XML = "xml"
-    private const val TEMPLATE_TYPE_COMPOSE = "compose"
+    private const val TEMPLATE_XML = "xml"
+    private const val TEMPLATE_COMPOSE = "compose"
     private const val TEMPLATE_XML_FOLDER_NAME = "template-xml"
     private const val TEMPLATE_COMPOSE_FOLDER_NAME = "template-compose"
 
@@ -37,11 +37,11 @@ object NewProject {
         Run kscript new_project.kts to create a new project with the following arguments:
             $KEY_PACKAGE_NAME=   New package name (i.e., com.example.package)
             $KEY_APP_NAME=       New app name (i.e., MyApp, "My App", "my-app")
-            $KEY_TEMPLATE=  Template type (i.e., $TEMPLATE_TYPE_XML, $TEMPLATE_TYPE_COMPOSE)
+            $KEY_TEMPLATE=  Template type (i.e., $TEMPLATE_XML, $TEMPLATE_COMPOSE)
         
         Examples:
-            kscript new_project.kts $KEY_PACKAGE_NAME=co.myproject.example $KEY_APP_NAME="My Project" $KEY_TEMPLATE=$TEMPLATE_TYPE_XML
-            kscript scripts/new_project.kts $KEY_PACKAGE_NAME=co.myproject.example $KEY_APP_NAME="My Project" $KEY_TEMPLATE=$TEMPLATE_TYPE_XML
+            kscript new_project.kts $KEY_PACKAGE_NAME=co.myproject.example $KEY_APP_NAME="My Project" $KEY_TEMPLATE=$TEMPLATE_XML
+            kscript scripts/new_project.kts $KEY_PACKAGE_NAME=co.myproject.example $KEY_APP_NAME="My Project" $KEY_TEMPLATE=$TEMPLATE_XML
     """.trimIndent()
 
     private val modules = listOf("app", "data", "domain")
@@ -82,31 +82,31 @@ object NewProject {
             }
         }
 
-    private var templateType: String = ""
+    private var template: String = ""
 
     private val templatePackageName
-        get() = if (templateType == TEMPLATE_TYPE_XML) {
+        get() = if (template == TEMPLATE_XML) {
             TEMPLATE_PACKAGE_NAME_XML
         } else {
             TEMPLATE_PACKAGE_NAME_COMPOSE
         }
 
     private val templateFolderName
-        get() = if (templateType == TEMPLATE_TYPE_XML) {
+        get() = if (template == TEMPLATE_XML) {
             TEMPLATE_XML_FOLDER_NAME
         } else {
             TEMPLATE_COMPOSE_FOLDER_NAME
         }
 
     private val templateAppName
-        get() = if (templateType == TEMPLATE_TYPE_XML) {
+        get() = if (template == TEMPLATE_XML) {
             TEMPLATE_APP_NAME_XML
         } else {
             TEMPLATE_APP_NAME_COMPOSE
         }
 
     private val templateApplicationClassName
-        get() = if (templateType == TEMPLATE_TYPE_XML) {
+        get() = if (template == TEMPLATE_XML) {
             TEMPLATE_APPLICATION_CLASS_NAME_XML
         } else {
             TEMPLATE_APPLICATION_CLASS_NAME_COMPOSE
@@ -133,7 +133,7 @@ object NewProject {
     private fun handleArguments(args: Array<String>) {
         var hasAppName = false
         var hasPackageName = false
-        var hasTemplateType = false
+        var hasTemplate = false
         args.forEach { arg ->
             when {
                 arg == KEY_HELP -> {
@@ -154,8 +154,8 @@ object NewProject {
                 }
                 arg.startsWith("$KEY_TEMPLATE$DELIMITER_ARGUMENT") -> {
                     val (key, value) = arg.split(DELIMITER_ARGUMENT)
-                    validateTemplateTypeName(value)
-                    hasTemplateType = true
+                    validateTemplate(value)
+                    hasTemplate = true
                 }
                 else -> {
                     showMessage(
@@ -174,7 +174,7 @@ object NewProject {
                 message = "ERROR: No package name has been provided \n$helpMessage",
                 exitAfterMessage = true
             )
-            !hasTemplateType -> showMessage(
+            !hasTemplate -> showMessage(
                 message = "ERROR: No template type has been provided \n$helpMessage",
                 exitAfterMessage = true
             )
@@ -203,12 +203,12 @@ object NewProject {
         }
     }
 
-    private fun validateTemplateTypeName(value: String) {
-        if (value == TEMPLATE_TYPE_XML || value == TEMPLATE_TYPE_COMPOSE) {
-            templateType = value.trim()
+    private fun validateTemplate(value: String) {
+        if (value == TEMPLATE_XML || value == TEMPLATE_COMPOSE) {
+            template = value.trim()
         } else {
             showMessage(
-                message = "ERROR: Invalid Template Type: $value (can either be $TEMPLATE_TYPE_XML or $TEMPLATE_TYPE_COMPOSE) \n$helpMessage",
+                message = "ERROR: Invalid Template: $value (can either be $TEMPLATE_XML or $TEMPLATE_COMPOSE) \n$helpMessage",
                 exitAfterMessage = true
             )
         }

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -37,11 +37,11 @@ object NewProject {
         Run kscript new_project.kts to create a new project with the following arguments:
             $KEY_PACKAGE_NAME=   New package name (i.e., com.example.package)
             $KEY_APP_NAME=       New app name (i.e., MyApp, "My App", "my-app")
-            $KEY_TEMPLATE=  Template type (i.e., $TEMPLATE_XML, $TEMPLATE_COMPOSE)
+            $KEY_TEMPLATE=       Template (i.e., $TEMPLATE_XML, $TEMPLATE_COMPOSE)
         
         Examples:
-            kscript new_project.kts $KEY_PACKAGE_NAME=co.myproject.example $KEY_APP_NAME="My Project" $KEY_TEMPLATE=$TEMPLATE_XML
-            kscript scripts/new_project.kts $KEY_PACKAGE_NAME=co.myproject.example $KEY_APP_NAME="My Project" $KEY_TEMPLATE=$TEMPLATE_XML
+            kscript new_project.kts $KEY_PACKAGE_NAME=co.myxmlproject.example $KEY_APP_NAME="My XML Project" $KEY_TEMPLATE=$TEMPLATE_XML
+            kscript scripts/new_project.kts $KEY_PACKAGE_NAME=co.myxmlproject.example $KEY_APP_NAME="My XML Project" $KEY_TEMPLATE=$TEMPLATE_XML
     """.trimIndent()
 
     private val modules = listOf("app", "data", "domain")
@@ -175,7 +175,7 @@ object NewProject {
                 exitAfterMessage = true
             )
             !hasTemplate -> showMessage(
-                message = "ERROR: No template type has been provided \n$helpMessage",
+                message = "ERROR: No template has been provided \n$helpMessage",
                 exitAfterMessage = true
             )
         }

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -28,8 +28,8 @@ object NewProject {
     private const val TEMPLATE_PACKAGE_NAME_COMPOSE = "co.nimblehq.template.compose"
     private const val TEMPLATE_XML = "xml"
     private const val TEMPLATE_COMPOSE = "compose"
-    private const val TEMPLATE_XML_FOLDER_NAME = "template-xml"
-    private const val TEMPLATE_COMPOSE_FOLDER_NAME = "template-compose"
+    private const val TEMPLATE_FOLDER_NAME_XML = "template-xml"
+    private const val TEMPLATE_FOLDER_NAME_COMPOSE = "template-compose"
 
     private const val VERSION_FILE_NAME = "version.properties"
 
@@ -93,9 +93,9 @@ object NewProject {
 
     private val templateFolderName
         get() = if (template == TEMPLATE_XML) {
-            TEMPLATE_XML_FOLDER_NAME
+            TEMPLATE_FOLDER_NAME_XML
         } else {
-            TEMPLATE_COMPOSE_FOLDER_NAME
+            TEMPLATE_FOLDER_NAME_COMPOSE
         }
 
     private val templateAppName


### PR DESCRIPTION
- Closes #336 
- Closes #338 

## What happened 👀

Update `new_project.kts` to be able to generate either `xml` or `compose` template project.
- Add a new flag called `template`, the value can either be `xml` or `compose`
- Ensure a project can be generated correctly for both options
- Ensure the help message is up-to-date
- Update `verify_newproject_script.yml` so the CI still works correctly

## Insight 📝

- Add keys and names for both `xml` and `compose`
- Add logic to get keys and names depending on `template` type
- Add validation for `template` type
- Modify `verify_newproject_script.yml` to be able to run CI successfully
- Modify `README.md` for the update

## Proof Of Work 📹

| xml | compose |
|--|--|
| ![xml](https://user-images.githubusercontent.com/32578035/203943843-5241473f-0c50-4468-921b-392a0f6dea58.png) | ![Compose](https://user-images.githubusercontent.com/32578035/203943922-0f59e333-af32-4dcb-8d4a-fca3930d77a6.png) |

### No template type
<img width="682" alt="No template type" src="https://user-images.githubusercontent.com/32578035/203945135-35e8b31e-3101-49e1-bb39-cab83caf4873.png">

### Invalid template type
<img width="682" alt="Invalid template type" src="https://user-images.githubusercontent.com/32578035/203945288-628b3e02-fd22-482e-aadb-fe68e888998a.png">

