### PR TITLE
[#364] Migrate workflows setup-ruby action

### DIFF
--- a/.cicdtemplate/.github/workflows/review_pull_request.yml
+++ b/.cicdtemplate/.github/workflows/review_pull_request.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew koverMergedXmlReport
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
 

--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -55,7 +55,7 @@ jobs:
         run: ./gradlew koverMergedXmlReport
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
 


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/364

## What happened 👀
![Screen Shot 2565-12-08 at 11 15 33](https://user-images.githubusercontent.com/28002315/206387363-be815c3a-5c09-47ba-b951-575c734c460b.png)

The CI failed on step `Set up Ruby` because the current action is `deprecated` and is `no longer maintained.`

## Insight 📝

We must migrate `action` from `actions/setup-ruby@v1` to `ruby/setup-ruby@v1`. For more info https://github.com/actions/setup-ruby

## Proof Of Work 📹
![Screen Shot 2565-12-08 at 14 49 28](https://user-images.githubusercontent.com/28002315/206389791-6bbf4efa-90c9-455d-b97f-67ec3d66fbfa.png)


