### PR TITLE
[#361] Update new_project.kts to keep application name as is

### DIFF
--- a/sample-compose/app/src/main/AndroidManifest.xml
+++ b/sample-compose/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
 
     <application
-        android:name=".SampleComposeApplication"
+        android:name=".MainApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/MainApplication.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/MainApplication.kt
@@ -1,11 +1,11 @@
-package co.nimblehq.template.xml
+package co.nimblehq.sample.compose
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
 @HiltAndroidApp
-class TemplateXMLApplication : Application() {
+class MainApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()

--- a/sample-xml/app/src/main/AndroidManifest.xml
+++ b/sample-xml/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
 
     <application
-        android:name=".SampleXmlApplication"
+        android:name=".MainApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/MainApplication.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/MainApplication.kt
@@ -1,11 +1,11 @@
-package co.nimblehq.template.compose
+package co.nimblehq.sample.xml
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
 @HiltAndroidApp
-class TemplateComposeApplication : Application() {
+class MainApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -22,8 +22,6 @@ object NewProject {
 
     private const val TEMPLATE_APP_NAME_XML = "Template XML"
     private const val TEMPLATE_APP_NAME_COMPOSE = "Template Compose"
-    private const val TEMPLATE_APPLICATION_CLASS_NAME_XML = "TemplateXMLApplication"
-    private const val TEMPLATE_APPLICATION_CLASS_NAME_COMPOSE = "TemplateComposeApplication"
     private const val TEMPLATE_PACKAGE_NAME_XML = "co.nimblehq.template.xml"
     private const val TEMPLATE_PACKAGE_NAME_COMPOSE = "co.nimblehq.template.compose"
     private const val TEMPLATE_XML = "xml"
@@ -62,12 +60,6 @@ object NewProject {
 
     private var packageName = ""
 
-    private val appNameWithoutSpace: String
-        get() = appName.getStringWithoutSpace()
-
-    private val applicationClassName: String
-        get() = "${appNameWithoutSpace}Application"
-
     private var projectFolderName: String = ""
 
     private val projectPath: String
@@ -105,13 +97,6 @@ object NewProject {
             TEMPLATE_APP_NAME_COMPOSE
         }
 
-    private val templateApplicationClassName
-        get() = if (template == TEMPLATE_XML) {
-            TEMPLATE_APPLICATION_CLASS_NAME_XML
-        } else {
-            TEMPLATE_APPLICATION_CLASS_NAME_COMPOSE
-        }
-
     fun generate(args: Array<String>) {
         showScriptVersion()
         handleArguments(args)
@@ -119,7 +104,6 @@ object NewProject {
         cleanNewProjectFolder()
         renamePackageNameFolders()
         renamePackageNameWithinFiles()
-        renameApplicationClass()
         renameAppName()
         buildProjectAndRunTests()
     }
@@ -292,28 +276,6 @@ object NewProject {
                     oldValue = templatePackageName,
                     newValue = packageName
                 )
-            }
-    }
-
-    private fun renameApplicationClass() {
-        showMessage("=> 🔎 Renaming application class...")
-        File(projectPath)
-            .walk()
-            .filter { it.name == "${templateApplicationClassName}.kt" || it.name == "AndroidManifest.xml" }
-            .forEach { file ->
-                rename(
-                    sourcePath = file.absolutePath,
-                    oldValue = templateApplicationClassName,
-                    newValue = applicationClassName
-                )
-                if (file.name == "${templateApplicationClassName}.kt") {
-                    val newApplicationPath = file.absolutePath.replaceAfterLast(
-                        delimiter = fileSeparator,
-                        replacement = "$applicationClassName.kt"
-                    )
-                    val newApplicationFile = File(newApplicationPath)
-                    file.renameTo(newApplicationFile)
-                }
             }
     }
 

--- a/template-compose/app/src/main/AndroidManifest.xml
+++ b/template-compose/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:name="co.nimblehq.template.compose.TemplateComposeApplication"
+        android:name=".MainApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/MainApplication.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/MainApplication.kt
@@ -1,11 +1,11 @@
-package co.nimblehq.sample.xml
+package co.nimblehq.template.compose
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
 @HiltAndroidApp
-class SampleXmlApplication : Application() {
+class MainApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()

--- a/template-xml/app/src/main/AndroidManifest.xml
+++ b/template-xml/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:name=".TemplateXMLApplication"
+        android:name=".MainApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/MainApplication.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/MainApplication.kt
@@ -1,11 +1,11 @@
-package co.nimblehq.sample.compose
+package co.nimblehq.template.xml
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
 @HiltAndroidApp
-class SampleComposeApplication : Application() {
+class MainApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()


### PR DESCRIPTION
closes #361

## What happened 👀

- Removed `renameApplicationClass()`, `appNameWithoutSpace` and `applicationClassName` from new_project script
- Renamed all Application classes to `MainApplication`

## Proof Of Work 📹

| XML | Compose |
| --- | --- |
| <img width="414" alt="xml" src="https://user-images.githubusercontent.com/53168251/206683751-e7351da1-4e6a-4ac5-b343-4edcdc8adddd.png"> | <img width="430" alt="compose" src="https://user-images.githubusercontent.com/53168251/206683731-ea5112de-5580-490f-8747-eeac4875ace5.png"> |
