### PR TITLE
[#369] Update deprecated Detekt attrs in all templates

### DIFF
--- a/sample-compose/detekt-config.yml
+++ b/sample-compose/detekt-config.yml
@@ -70,7 +70,7 @@ complexity:
     threshold: 20
   LongParameterList:
     active: true
-    threshold: 5
+    functionThreshold: 5
     ignoreDefaultParameters: true
   MethodOverloading:
     active: false
@@ -127,7 +127,7 @@ exceptions:
   active: true
   ExceptionRaisedInUnexpectedLocation:
     active: false
-    methodNames: 'toString,hashCode,equals,finalize'
+    methodNames: [ 'toString', 'hashCode', 'equals', 'finalize' ]
   InstanceOfCheckForException:
     active: false
   NotImplementedDeclaration:
@@ -146,7 +146,7 @@ exceptions:
     active: false
   ThrowingExceptionsWithoutMessageOrCause:
     active: false
-    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+    exceptions: [ 'IllegalArgumentException', 'IllegalStateException', 'IOException' ]
   ThrowingNewInstanceOfSameException:
     active: false
   TooGenericExceptionCaught:
@@ -179,7 +179,7 @@ naming:
     enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
   ForbiddenClassName:
     active: false
-    forbiddenName: ''
+    forbiddenName: [ '' ]
   FunctionMaxLength:
     active: false
     maximumFunctionNameLength: 30
@@ -188,13 +188,13 @@ naming:
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+    functionPattern: '[a-zA-Z][a-zA-Z0-9]*'
     ignoreAnnotated: [ 'Composable' ]
   MatchingDeclarationName:
     active: true
   MemberNameEqualsClassName:
     active: false
-    ignoreOverriddenFunction: true
+    ignoreOverridden: true
   ObjectPropertyNaming:
     active: true
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
@@ -244,7 +244,7 @@ potential-bugs:
     active: false
   LateinitUsage:
     active: false
-    excludeAnnotatedProperties: ""
+    ignoreAnnotated: [ '' ]
     ignoreOnClassesPattern: ""
   UnconditionalJumpStatementInLoop:
     active: false
@@ -272,10 +272,10 @@ style:
     active: false
   ForbiddenComment:
     active: true
-    values: 'FIXME:,STOPSHIP:'
+    values: [ 'FIXME:', 'STOPSHIP:' ]
   ForbiddenImport:
     active: false
-    imports: ''
+    imports: [ '' ]
   FunctionOnlyReturningConstant:
     active: false
     ignoreOverridableFunction: true
@@ -285,7 +285,7 @@ style:
     maxJumpCount: 1
   MagicNumber:
     active: true
-    ignoreNumbers: '-1,0,1,2'
+    ignoreNumbers: [ '-1', '0', '1', '2' ]
     ignoreHashCodeFunction: false
     ignorePropertyDeclaration: true
     ignoreConstantDeclaration: true
@@ -342,7 +342,7 @@ style:
     ignoreAnnotated: [ 'Preview' ]
   UseDataClass:
     active: false
-    excludeAnnotatedClasses: ""
+    ignoreAnnotated: [ '' ]
   UtilityClassWithPublicConstructor:
     active: false
   WildcardImport:

--- a/sample-compose/detekt-config.yml
+++ b/sample-compose/detekt-config.yml
@@ -152,22 +152,22 @@ exceptions:
   TooGenericExceptionCaught:
     active: true
     exceptionNames:
-     - ArrayIndexOutOfBoundsException
-     - Error
-     - Exception
-     - IllegalMonitorStateException
-     - NullPointerException
-     - IndexOutOfBoundsException
-     - RuntimeException
-     - Throwable
+      - ArrayIndexOutOfBoundsException
+      - Error
+      - Exception
+      - IllegalMonitorStateException
+      - NullPointerException
+      - IndexOutOfBoundsException
+      - RuntimeException
+      - Throwable
   TooGenericExceptionThrown:
     active: true
     exceptionNames:
-     - Error
-     - Exception
-     - NullPointerException
-     - Throwable
-     - RuntimeException
+      - Error
+      - Exception
+      - NullPointerException
+      - Throwable
+      - RuntimeException
 
 naming:
   active: true

--- a/sample-xml/detekt-config.yml
+++ b/sample-xml/detekt-config.yml
@@ -152,22 +152,22 @@ exceptions:
   TooGenericExceptionCaught:
     active: true
     exceptionNames:
-     - ArrayIndexOutOfBoundsException
-     - Error
-     - Exception
-     - IllegalMonitorStateException
-     - NullPointerException
-     - IndexOutOfBoundsException
-     - RuntimeException
-     - Throwable
+      - ArrayIndexOutOfBoundsException
+      - Error
+      - Exception
+      - IllegalMonitorStateException
+      - NullPointerException
+      - IndexOutOfBoundsException
+      - RuntimeException
+      - Throwable
   TooGenericExceptionThrown:
     active: true
     exceptionNames:
-     - Error
-     - Exception
-     - NullPointerException
-     - Throwable
-     - RuntimeException
+      - Error
+      - Exception
+      - NullPointerException
+      - Throwable
+      - RuntimeException
 
 naming:
   active: true

--- a/sample-xml/detekt-config.yml
+++ b/sample-xml/detekt-config.yml
@@ -70,7 +70,7 @@ complexity:
     threshold: 20
   LongParameterList:
     active: true
-    threshold: 5
+    functionThreshold: 5
     ignoreDefaultParameters: false
   MethodOverloading:
     active: false
@@ -127,7 +127,7 @@ exceptions:
   active: true
   ExceptionRaisedInUnexpectedLocation:
     active: false
-    methodNames: 'toString,hashCode,equals,finalize'
+    methodNames: [ 'toString', 'hashCode', 'equals', 'finalize' ]
   InstanceOfCheckForException:
     active: false
   NotImplementedDeclaration:
@@ -146,7 +146,7 @@ exceptions:
     active: false
   ThrowingExceptionsWithoutMessageOrCause:
     active: false
-    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+    exceptions: [ 'IllegalArgumentException', 'IllegalStateException', 'IOException' ]
   ThrowingNewInstanceOfSameException:
     active: false
   TooGenericExceptionCaught:
@@ -179,7 +179,7 @@ naming:
     enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
   ForbiddenClassName:
     active: false
-    forbiddenName: ''
+    forbiddenName: [ '' ]
   FunctionMaxLength:
     active: false
     maximumFunctionNameLength: 30
@@ -188,12 +188,12 @@ naming:
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+    functionPattern: '[a-zA-Z][a-zA-Z0-9]*'
   MatchingDeclarationName:
     active: true
   MemberNameEqualsClassName:
     active: false
-    ignoreOverriddenFunction: true
+    ignoreOverridden: true
   ObjectPropertyNaming:
     active: true
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
@@ -243,7 +243,7 @@ potential-bugs:
     active: false
   LateinitUsage:
     active: false
-    excludeAnnotatedProperties: ""
+    ignoreAnnotated: [ '' ]
     ignoreOnClassesPattern: ""
   UnconditionalJumpStatementInLoop:
     active: false
@@ -271,10 +271,10 @@ style:
     active: false
   ForbiddenComment:
     active: true
-    values: 'FIXME:,STOPSHIP:'
+    values: [ 'FIXME:', 'STOPSHIP:' ]
   ForbiddenImport:
     active: false
-    imports: ''
+    imports: [ '' ]
   FunctionOnlyReturningConstant:
     active: false
     ignoreOverridableFunction: true
@@ -284,7 +284,7 @@ style:
     maxJumpCount: 1
   MagicNumber:
     active: true
-    ignoreNumbers: '-1,0,1,2'
+    ignoreNumbers: [ '-1', '0', '1', '2' ]
     ignoreHashCodeFunction: false
     ignorePropertyDeclaration: false
     ignoreConstantDeclaration: true
@@ -338,7 +338,7 @@ style:
     active: false
   UseDataClass:
     active: false
-    excludeAnnotatedClasses: ""
+    ignoreAnnotated: [ '' ]
   UtilityClassWithPublicConstructor:
     active: false
   WildcardImport:

--- a/sample-xml/detekt-config.yml
+++ b/sample-xml/detekt-config.yml
@@ -336,6 +336,8 @@ style:
     active: false
   UnusedImports:
     active: false
+  UnusedPrivateMember:
+    active: true
   UseDataClass:
     active: false
     ignoreAnnotated: [ '' ]

--- a/template-compose/detekt-config.yml
+++ b/template-compose/detekt-config.yml
@@ -152,22 +152,22 @@ exceptions:
   TooGenericExceptionCaught:
     active: true
     exceptionNames:
-     - ArrayIndexOutOfBoundsException
-     - Error
-     - Exception
-     - IllegalMonitorStateException
-     - NullPointerException
-     - IndexOutOfBoundsException
-     - RuntimeException
-     - Throwable
+      - ArrayIndexOutOfBoundsException
+      - Error
+      - Exception
+      - IllegalMonitorStateException
+      - NullPointerException
+      - IndexOutOfBoundsException
+      - RuntimeException
+      - Throwable
   TooGenericExceptionThrown:
     active: true
     exceptionNames:
-     - Error
-     - Exception
-     - NullPointerException
-     - Throwable
-     - RuntimeException
+      - Error
+      - Exception
+      - NullPointerException
+      - Throwable
+      - RuntimeException
 
 naming:
   active: true

--- a/template-compose/detekt-config.yml
+++ b/template-compose/detekt-config.yml
@@ -70,7 +70,7 @@ complexity:
     threshold: 20
   LongParameterList:
     active: true
-    threshold: 5
+    functionThreshold: 5
     ignoreDefaultParameters: true
   MethodOverloading:
     active: false
@@ -127,7 +127,7 @@ exceptions:
   active: true
   ExceptionRaisedInUnexpectedLocation:
     active: false
-    methodNames: 'toString,hashCode,equals,finalize'
+    methodNames: [ 'toString', 'hashCode', 'equals' , 'finalize' ]
   InstanceOfCheckForException:
     active: false
   NotImplementedDeclaration:
@@ -146,7 +146,7 @@ exceptions:
     active: false
   ThrowingExceptionsWithoutMessageOrCause:
     active: false
-    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+    exceptions: [ 'IllegalArgumentException', 'IllegalStateException', 'IOException' ]
   ThrowingNewInstanceOfSameException:
     active: false
   TooGenericExceptionCaught:
@@ -179,7 +179,7 @@ naming:
     enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
   ForbiddenClassName:
     active: false
-    forbiddenName: ''
+    forbiddenName: [ '' ]
   FunctionMaxLength:
     active: false
     maximumFunctionNameLength: 30
@@ -188,13 +188,13 @@ naming:
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+    functionPattern: '[a-zA-Z][a-zA-Z0-9]*'
     ignoreAnnotated: [ 'Composable' ]
   MatchingDeclarationName:
     active: true
   MemberNameEqualsClassName:
     active: false
-    ignoreOverriddenFunction: true
+    ignoreOverridden: true
   ObjectPropertyNaming:
     active: true
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
@@ -244,7 +244,7 @@ potential-bugs:
     active: false
   LateinitUsage:
     active: false
-    excludeAnnotatedProperties: ""
+    ignoreAnnotated: [ '' ]
     ignoreOnClassesPattern: ""
   UnconditionalJumpStatementInLoop:
     active: false
@@ -272,10 +272,10 @@ style:
     active: false
   ForbiddenComment:
     active: true
-    values: 'FIXME:,STOPSHIP:'
+    values: [ 'FIXME:', 'STOPSHIP:' ]
   ForbiddenImport:
     active: false
-    imports: ''
+    imports: [ '' ]
   FunctionOnlyReturningConstant:
     active: false
     ignoreOverridableFunction: true
@@ -285,7 +285,7 @@ style:
     maxJumpCount: 1
   MagicNumber:
     active: true
-    ignoreNumbers: '-1,0,1,2'
+    ignoreNumbers: [ '-1', '0', '1', '2' ]
     ignoreHashCodeFunction: false
     ignorePropertyDeclaration: true
     ignoreConstantDeclaration: true
@@ -342,7 +342,7 @@ style:
     ignoreAnnotated: [ 'Preview' ]
   UseDataClass:
     active: false
-    excludeAnnotatedClasses: ""
+    ignoreAnnotated: [ '' ]
   UtilityClassWithPublicConstructor:
     active: false
   WildcardImport:

--- a/template-xml/detekt-config.yml
+++ b/template-xml/detekt-config.yml
@@ -152,22 +152,22 @@ exceptions:
   TooGenericExceptionCaught:
     active: true
     exceptionNames:
-     - ArrayIndexOutOfBoundsException
-     - Error
-     - Exception
-     - IllegalMonitorStateException
-     - NullPointerException
-     - IndexOutOfBoundsException
-     - RuntimeException
-     - Throwable
+      - ArrayIndexOutOfBoundsException
+      - Error
+      - Exception
+      - IllegalMonitorStateException
+      - NullPointerException
+      - IndexOutOfBoundsException
+      - RuntimeException
+      - Throwable
   TooGenericExceptionThrown:
     active: true
     exceptionNames:
-     - Error
-     - Exception
-     - NullPointerException
-     - Throwable
-     - RuntimeException
+      - Error
+      - Exception
+      - NullPointerException
+      - Throwable
+      - RuntimeException
 
 naming:
   active: true

--- a/template-xml/detekt-config.yml
+++ b/template-xml/detekt-config.yml
@@ -70,7 +70,7 @@ complexity:
     threshold: 20
   LongParameterList:
     active: true
-    threshold: 5
+    functionThreshold: 5
     ignoreDefaultParameters: false
   MethodOverloading:
     active: false
@@ -127,7 +127,7 @@ exceptions:
   active: true
   ExceptionRaisedInUnexpectedLocation:
     active: false
-    methodNames: 'toString,hashCode,equals,finalize'
+    methodNames: [ 'toString', 'hashCode', 'equals', 'finalize' ]
   InstanceOfCheckForException:
     active: false
   NotImplementedDeclaration:
@@ -146,7 +146,7 @@ exceptions:
     active: false
   ThrowingExceptionsWithoutMessageOrCause:
     active: false
-    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+    exceptions: [ 'IllegalArgumentException', 'IllegalStateException', 'IOException' ]
   ThrowingNewInstanceOfSameException:
     active: false
   TooGenericExceptionCaught:
@@ -179,7 +179,7 @@ naming:
     enumEntryPattern: '^[A-Z$][a-zA-Z_$]*$'
   ForbiddenClassName:
     active: false
-    forbiddenName: ''
+    forbiddenName: [ '' ]
   FunctionMaxLength:
     active: false
     maximumFunctionNameLength: 30
@@ -188,12 +188,12 @@ naming:
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+    functionPattern: '[a-zA-Z][a-zA-Z0-9]*'
   MatchingDeclarationName:
     active: true
   MemberNameEqualsClassName:
     active: false
-    ignoreOverriddenFunction: true
+    ignoreOverridden: true
   ObjectPropertyNaming:
     active: true
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
@@ -243,7 +243,7 @@ potential-bugs:
     active: false
   LateinitUsage:
     active: false
-    excludeAnnotatedProperties: ""
+    ignoreAnnotated: [ '' ]
     ignoreOnClassesPattern: ""
   UnconditionalJumpStatementInLoop:
     active: false
@@ -271,10 +271,10 @@ style:
     active: false
   ForbiddenComment:
     active: true
-    values: 'FIXME:,STOPSHIP:'
+    values: [ 'FIXME:', 'STOPSHIP:' ]
   ForbiddenImport:
     active: false
-    imports: ''
+    imports: [ '' ]
   FunctionOnlyReturningConstant:
     active: false
     ignoreOverridableFunction: true
@@ -284,7 +284,7 @@ style:
     maxJumpCount: 1
   MagicNumber:
     active: true
-    ignoreNumbers: '-1,0,1,2'
+    ignoreNumbers: [ '-1', '0', '1', '2' ]
     ignoreHashCodeFunction: false
     ignorePropertyDeclaration: false
     ignoreConstantDeclaration: true
@@ -338,7 +338,7 @@ style:
     active: false
   UseDataClass:
     active: false
-    excludeAnnotatedClasses: ""
+    ignoreAnnotated: [ '' ]
   UtilityClassWithPublicConstructor:
     active: false
   WildcardImport:

--- a/template-xml/detekt-config.yml
+++ b/template-xml/detekt-config.yml
@@ -336,6 +336,8 @@ style:
     active: false
   UnusedImports:
     active: false
+  UnusedPrivateMember:
+    active: true
   UseDataClass:
     active: false
     ignoreAnnotated: [ '' ]


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/369

## What happened 👀

![Screen Shot 2565-12-12 at 15 17 38](https://user-images.githubusercontent.com/28002315/206995395-c74c98b2-73ee-4e09-8478-fbb7515e3960.png)

There is some `Detekt attrs` deprecated need to fix them.

## Insight 📝

- Update `attr` -> `threshold` to `functionThreshold` for `LongParameterList`.
- Update `attr` -> `ignoreOverriddenFunction` to `ignoreOverridden` for `MemberNameEqualsClassName`.
- Update `attr` -> `excludeAnnotatedProperties` to `ignoreAnnotated` for `LateinitUsage`.
- Update `attr` -> `excludeAnnotatedClasses` to `ignoreAnnotated` for `UseDataClass`.
- And for the left, we need to use `YAML array` instead of `comma-separated` string by following this pattern `[ '' ]`.
- We have updated `functionPattern` for `FunctionNaming` from ``^([a-z$][a-zA-Z$0-9]*)|(`.*`)$`` to `[a-zA-Z][a-zA-Z0-9]` to make it shorter.
- Add `UnusedPrivateMember` as we have this in `template/sample-compose` and It's good to have this to recheck unused private `properties` or `functions.`

## Proof Of Work 📹
![Screen Shot 2565-12-13 at 10 50 38](https://user-images.githubusercontent.com/28002315/207222598-15fb849a-ff07-4e4c-be5c-e2c96b78e587.png)

![Screen Shot 2565-12-13 at 10 51 42](https://user-images.githubusercontent.com/28002315/207222616-71c89484-4fc5-4307-a641-48fcc68bb62f.png)

![Screen Shot 2565-12-13 at 10 52 35](https://user-images.githubusercontent.com/28002315/207222633-0232a1fe-4929-4dd2-9032-355c68eeeb03.png)

![Screen Shot 2565-12-13 at 10 55 00](https://user-images.githubusercontent.com/28002315/207222654-6b657960-b752-4ab6-9269-b2a1622a1caf.png)
