### PR TITLE
[#370] [Compose] Migrate to the new permission request logic

### DIFF
--- a/sample-compose/app/build.gradle.kts
+++ b/sample-compose/app/build.gradle.kts
@@ -133,7 +133,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN_VERSION}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.KOTLINX_COROUTINES_VERSION}")
 
-    implementation("com.markodevcic:peko:${Versions.PEKO_VERSION}")
+    implementation("com.google.accompanist:accompanist-permissions:${Versions.ACCOMPANIST_PERMISSIONS_VERSION}")
 
     kapt("com.google.dagger:hilt-compiler:${Versions.HILT_VERSION}")
 

--- a/sample-compose/app/src/main/AndroidManifest.xml
+++ b/sample-compose/app/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
     package="co.nimblehq.sample.compose">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
 
     <application

--- a/sample-compose/app/src/main/AndroidManifest.xml
+++ b/sample-compose/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="co.nimblehq.sample.compose">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
 

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
@@ -39,7 +39,7 @@ fun HomeScreen(
     val showLoading: IsLoading by viewModel.showLoading.collectAsState()
     val uiModels: List<UiModel> by viewModel.uiModels.collectAsState()
 
-    CheckCameraPermission()
+    CameraPermission()
 
     HomeScreenContent(
         uiModels = uiModels,
@@ -53,7 +53,7 @@ fun HomeScreen(
  */
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-private fun CheckCameraPermission() {
+private fun CameraPermission() {
     val context = LocalContext.current
     val cameraPermissionState = rememberPermissionState(CAMERA)
     if (cameraPermissionState.status.isGranted) {

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
@@ -49,7 +49,7 @@ fun HomeScreen(
 }
 
 /**
- * The permission check composable needs to be separate from the HomeScreenContent composable to avoid re-composition
+ * [CameraPermission] needs to be separate from [HomeScreenContent] to avoid re-composition
  */
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
@@ -19,7 +19,6 @@ import co.nimblehq.sample.compose.ui.screens.AppBar
 import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 import co.nimblehq.sample.compose.ui.userReadableMessage
 import com.google.accompanist.permissions.*
-import timber.log.Timber
 
 @Composable
 fun HomeScreen(
@@ -40,6 +39,8 @@ fun HomeScreen(
     val showLoading: IsLoading by viewModel.showLoading.collectAsState()
     val uiModels: List<UiModel> by viewModel.uiModels.collectAsState()
 
+    CheckCameraPermission()
+
     HomeScreenContent(
         uiModels = uiModels,
         showLoading = showLoading,
@@ -47,28 +48,39 @@ fun HomeScreen(
     )
 }
 
+/**
+ * The permission check composable needs to be separate from the HomeScreenContent composable to avoid re-composition
+ */
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-private fun HomeScreenContent(
-    uiModels: List<UiModel>,
-    showLoading: IsLoading,
-    onItemClick: (UiModel) -> Unit
-) {
+private fun CheckCameraPermission() {
+    val context = LocalContext.current
     val cameraPermissionState = rememberPermissionState(CAMERA)
     if (cameraPermissionState.status.isGranted) {
-        Timber.d("${cameraPermissionState.permission} granted")
+        Toast.makeText(context, "${cameraPermissionState.permission} granted", Toast.LENGTH_SHORT).show()
     } else {
         if (cameraPermissionState.status.shouldShowRationale) {
-            Timber.d("${cameraPermissionState.permission} needs rationale")
+            Toast.makeText(context, "${cameraPermissionState.permission} needs rationale", Toast.LENGTH_SHORT).show()
         } else {
-            Timber.d("Request cancelled, missing permissions in manifest or denied permanently")
+            Toast.makeText(
+                context,
+                "Request cancelled, missing permissions in manifest or denied permanently",
+                Toast.LENGTH_SHORT
+            ).show()
         }
 
         LaunchedEffect(Unit) {
             cameraPermissionState.launchPermissionRequest()
         }
     }
+}
 
+@Composable
+private fun HomeScreenContent(
+    uiModels: List<UiModel>,
+    showLoading: IsLoading,
+    onItemClick: (UiModel) -> Unit
+) {
     Scaffold(topBar = {
         AppBar(R.string.home_title_bar)
     }) { paddingValues ->

--- a/sample-compose/buildSrc/src/main/java/Versions.kt
+++ b/sample-compose/buildSrc/src/main/java/Versions.kt
@@ -9,6 +9,7 @@ object Versions {
     const val ANDROID_VERSION_NAME = "3.15.0"
 
     // Dependencies (Alphabet sorted)
+    const val ACCOMPANIST_PERMISSIONS_VERSION = "0.28.0"
     const val ANDROID_COMMON_KTX_VERSION = "0.1.1"
     const val ANDROID_CRYPTO_VERSION = "1.0.0"
     const val ANDROIDX_CORE_KTX_VERSION = "1.9.0"
@@ -32,8 +33,6 @@ object Versions {
     const val MOSHI_VERSION = "1.12.0"
 
     const val OKHTTP_VERSION = "4.9.1"
-
-    const val PEKO_VERSION = "2.1.2"
 
     const val RETROFIT_VERSION = "2.9.0"
 

--- a/template-compose/app/build.gradle.kts
+++ b/template-compose/app/build.gradle.kts
@@ -133,7 +133,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN_VERSION}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.KOTLINX_COROUTINES_VERSION}")
 
-    implementation("com.markodevcic:peko:${Versions.PEKO_VERSION}")
+    implementation("com.google.accompanist:accompanist-permissions:${Versions.ACCOMPANIST_PERMISSIONS_VERSION}")
 
     kapt("com.google.dagger:hilt-compiler:${Versions.HILT_VERSION}")
 

--- a/template-compose/buildSrc/src/main/java/Versions.kt
+++ b/template-compose/buildSrc/src/main/java/Versions.kt
@@ -9,6 +9,7 @@ object Versions {
     const val ANDROID_VERSION_NAME = "1.0.0"
 
     // Dependencies (Alphabet sorted)
+    const val ACCOMPANIST_PERMISSIONS_VERSION = "0.28.0"
     const val ANDROID_COMMON_KTX_VERSION = "0.1.1"
     const val ANDROID_CRYPTO_VERSION = "1.0.0"
     const val ANDROIDX_CORE_KTX_VERSION = "1.9.0"
@@ -32,8 +33,6 @@ object Versions {
     const val MOSHI_VERSION = "1.12.0"
 
     const val OKHTTP_VERSION = "4.9.1"
-
-    const val PEKO_VERSION = "2.1.2"
 
     const val RETROFIT_VERSION = "2.9.0"
 


### PR DESCRIPTION
Solves https://github.com/nimblehq/android-templates/issues/370

## What happened 👀

- Migrating legacy permission requests on Fragment to the new approach in Jetpack Compose by removing `Peko` and switching to use https://google.github.io/accompanist/permissions/.

## Insight 📝

From what we have done in this PR https://github.com/nimblehq/android-templates/pull/324, we need to migrate all related `Peko` permission request stuff to [Accompanist permissions](https://google.github.io/accompanist/permissions) for Compose projects.

## Proof Of Work 📹


https://user-images.githubusercontent.com/16315358/207667660-4b3faebc-7cb9-4dc0-ab7e-441f879c028e.mp4


