### PR TITLE
[#353] [Compose] Set up app resources and theme management

### DIFF
--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/AppBar.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/AppBar.kt
@@ -7,12 +7,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import co.nimblehq.sample.compose.R
+import co.nimblehq.sample.compose.ui.theme.AppTheme.colors
 import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 
 @Composable
 fun AppBar(@StringRes title: Int) {
     TopAppBar(
-        title = { Text(text = stringResource(title)) }
+        title = { Text(text = stringResource(title)) },
+        backgroundColor = colors.topAppBarBackground
     )
 }
 

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
@@ -7,8 +7,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import co.nimblehq.sample.compose.model.UiModel
+import co.nimblehq.sample.compose.ui.theme.AppTheme.dimensions
 import co.nimblehq.sample.compose.ui.theme.ComposeTheme
-import co.nimblehq.sample.compose.ui.theme.SpacingNormal
 
 @Composable
 fun Item(
@@ -21,7 +21,7 @@ fun Item(
             .clickable(onClick = { onClick(uiModel) })
     ) {
         Text(
-            modifier = Modifier.padding(SpacingNormal),
+            modifier = Modifier.padding(dimensions.spacingNormal),
             text = uiModel.id
         )
     }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppColors.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppColors.kt
@@ -4,8 +4,11 @@ import androidx.compose.material.*
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 
+// Base colors here
+internal val GreenCitrus = Color(0xFF99CC00)
+
 /**
- * Extend final [Colors] class to provide more custom app colors.
+ * Expand the final [Colors] class to provide more custom app colors.
  */
 data class AppColors(
     val themeColors: Colors,
@@ -22,4 +25,4 @@ internal val DarkColorPalette = AppColors(
     themeColors = darkColors()
 )
 
-internal val LocalColors = staticCompositionLocalOf { LightColorPalette }
+internal val LocalAppColors = staticCompositionLocalOf { LightColorPalette }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppColors.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppColors.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
  * Extend final [Colors] class to provide more custom app colors.
  */
 data class AppColors(
-    val themeColors: Colors,
+    val themeColors: Colors
 
     // Custom colors here
 )

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppColors.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppColors.kt
@@ -2,28 +2,24 @@ package co.nimblehq.sample.compose.ui.theme
 
 import androidx.compose.material.*
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
 
 /**
  * Extend final [Colors] class to provide more custom app colors.
  */
 data class AppColors(
-    val themeColors: Colors
+    val themeColors: Colors,
 
     // Custom colors here
+    val topAppBarBackground: Color = GreenCitrus
 )
 
 internal val LightColorPalette = AppColors(
-    themeColors = lightColors(
-        primary = GreenCitrus,
-        secondary = GreenChristi
-    )
+    themeColors = lightColors()
 )
 
 internal val DarkColorPalette = AppColors(
-    themeColors = darkColors(
-        primary = GreenCitrus,
-        secondary = GreenChristi
-    )
+    themeColors = darkColors()
 )
 
 internal val LocalColors = staticCompositionLocalOf { LightColorPalette }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppColors.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppColors.kt
@@ -1,0 +1,27 @@
+package co.nimblehq.sample.compose.ui.theme
+
+import androidx.compose.material.*
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Extend final [Colors] class to provide more custom app colors.
+ */
+data class AppColors(
+    val themeColors: Colors,
+
+    // Custom colors here
+)
+
+internal val LightColorPalette = AppColors(
+    themeColors = lightColors(
+        primary = GreenCitrus
+    )
+)
+
+internal val DarkColorPalette = AppColors(
+    themeColors = darkColors(
+        primary = GreenCitrus
+    )
+)
+
+internal val LocalColors = staticCompositionLocalOf { LightColorPalette }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppDimensions.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppDimensions.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.dp
 
 class AppDimensions {
-    // Custom colors here
+    // Custom dimensions here
     val spacingNormal = 16.dp
 }
 

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppDimensions.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppDimensions.kt
@@ -1,0 +1,11 @@
+package co.nimblehq.sample.compose.ui.theme
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.dp
+
+class AppDimensions {
+    // Custom colors here
+    val spacingNormal = 16.dp
+}
+
+internal val LocalAppDimensions = staticCompositionLocalOf { AppDimensions() }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppShapes.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppShapes.kt
@@ -1,0 +1,10 @@
+package co.nimblehq.sample.compose.ui.theme
+
+import androidx.compose.material.Shapes
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val Shapes = Shapes(
+    // Custom shapes here
+)
+
+internal val LocalAppShapes = staticCompositionLocalOf { Shapes }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppStyles.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppStyles.kt
@@ -1,0 +1,9 @@
+package co.nimblehq.sample.compose.ui.theme
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+class AppStyles {
+    // Custom styles here
+}
+
+internal val LocalAppStyles = staticCompositionLocalOf { AppStyles() }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppTypography.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppTypography.kt
@@ -1,0 +1,10 @@
+package co.nimblehq.sample.compose.ui.theme
+
+import androidx.compose.material.Typography
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val Typography = Typography(
+    // Custom TextStyle here
+)
+
+internal val LocalAppTypography = staticCompositionLocalOf { Typography }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppTypography.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppTypography.kt
@@ -4,7 +4,7 @@ import androidx.compose.material.Typography
 import androidx.compose.runtime.staticCompositionLocalOf
 
 private val Typography = Typography(
-    // Custom TextStyle here
+    // Custom typography here
 )
 
 internal val LocalAppTypography = staticCompositionLocalOf { Typography }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Color.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Color.kt
@@ -3,3 +3,4 @@ package co.nimblehq.sample.compose.ui.theme
 import androidx.compose.ui.graphics.Color
 
 internal val GreenCitrus = Color(0xFF99CC00)
+internal val GreenChristi = Color(0xFF669900)

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Color.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Color.kt
@@ -2,5 +2,5 @@ package co.nimblehq.sample.compose.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+// Base colors here
 internal val GreenCitrus = Color(0xFF99CC00)
-internal val GreenChristi = Color(0xFF669900)

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Color.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Color.kt
@@ -1,6 +1,0 @@
-package co.nimblehq.sample.compose.ui.theme
-
-import androidx.compose.ui.graphics.Color
-
-// Base colors here
-internal val GreenCitrus = Color(0xFF99CC00)

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Color.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Color.kt
@@ -2,4 +2,4 @@ package co.nimblehq.sample.compose.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val GreenCitrus = Color(0xFF99CC00)
+internal val GreenCitrus = Color(0xFF99CC00)

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Dimension.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Dimension.kt
@@ -1,5 +1,0 @@
-package co.nimblehq.sample.compose.ui.theme
-
-import androidx.compose.ui.unit.dp
-
-val SpacingNormal = 16.dp

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Theme.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Theme.kt
@@ -14,15 +14,11 @@ fun ComposeTheme(
     } else {
         LightColorPalette
     }
-    val dimensions = LocalAppDimensions.current
-    val styles = LocalAppStyles.current
     val typography = LocalAppTypography.current
     val shapes = LocalAppShapes.current
 
     CompositionLocalProvider(
-        LocalAppColors provides colors,
-        LocalAppDimensions provides dimensions,
-        LocalAppStyles provides styles
+        LocalAppColors provides colors
     ) {
         MaterialTheme(
             colors = colors.themeColors,

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Theme.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Theme.kt
@@ -17,7 +17,7 @@ fun ComposeTheme(
     val dimensions = LocalAppDimensions.current
     val styles = LocalAppStyles.current
     val typography = LocalAppTypography.current
-    val shapes = Shapes()
+    val shapes = LocalAppShapes.current
 
     CompositionLocalProvider(
         LocalAppColors provides colors,
@@ -52,7 +52,7 @@ object AppTheme {
     val shapes: Shapes
         @Composable
         @ReadOnlyComposable
-        get() = MaterialTheme.shapes
+        get() = LocalAppShapes.current
 
     val dimensions: AppDimensions
         @Composable

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Theme.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Theme.kt
@@ -1,17 +1,67 @@
 package co.nimblehq.sample.compose.ui.theme
 
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.lightColors
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.*
+import androidx.compose.runtime.*
 
 @Composable
 fun ComposeTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    MaterialTheme(
-        colors = lightColors(
-            primary = GreenCitrus
-        ),
-        content = content
-    )
+    val colors = if (darkTheme) {
+        DarkColorPalette
+    } else {
+        LightColorPalette
+    }
+    val dimensions = LocalAppDimensions.current
+    val styles = LocalAppStyles.current
+    val typography = LocalAppTypography.current
+    val shapes = Shapes()
+
+    CompositionLocalProvider(
+        LocalColors provides colors,
+        LocalAppDimensions provides dimensions,
+        LocalAppStyles provides styles
+    ) {
+        MaterialTheme(
+            colors = colors.themeColors,
+            typography = typography,
+            shapes = shapes,
+            content = content
+        )
+    }
 }
+
+/**
+ * Alternate to [MaterialTheme] allowing us to add our own theme systems
+ * or to extend [MaterialTheme]'s types e.g. return our own [Colors] extension.
+ */
+object AppTheme {
+
+    val colors: AppColors
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalColors.current
+
+    val typography: Typography
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalAppTypography.current
+
+    val shapes: Shapes
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.shapes
+
+    val dimensions: AppDimensions
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalAppDimensions.current
+
+    val styles: AppStyles
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalAppStyles.current
+}
+

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Theme.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Theme.kt
@@ -20,7 +20,7 @@ fun ComposeTheme(
     val shapes = Shapes()
 
     CompositionLocalProvider(
-        LocalColors provides colors,
+        LocalAppColors provides colors,
         LocalAppDimensions provides dimensions,
         LocalAppStyles provides styles
     ) {
@@ -42,7 +42,7 @@ object AppTheme {
     val colors: AppColors
         @Composable
         @ReadOnlyComposable
-        get() = LocalColors.current
+        get() = LocalAppColors.current
 
     val typography: Typography
         @Composable

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Theme.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/Theme.kt
@@ -64,4 +64,3 @@ object AppTheme {
         @ReadOnlyComposable
         get() = LocalAppStyles.current
 }
-

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeScreen.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeScreen.kt
@@ -11,8 +11,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import co.nimblehq.template.compose.R
 import co.nimblehq.template.compose.model.UiModel
 import co.nimblehq.template.compose.ui.AppDestination
+import co.nimblehq.template.compose.ui.theme.AppTheme.dimensions
 import co.nimblehq.template.compose.ui.theme.ComposeTheme
-import co.nimblehq.template.compose.ui.theme.Dimension.SpacingNormal
 import timber.log.Timber
 
 @Composable
@@ -42,7 +42,7 @@ private fun HomeScreenContent(
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(all = SpacingNormal)
+                .padding(all = dimensions.spacingNormal)
         )
     }
     Timber.d("Result : $uiModels")

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppColors.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppColors.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
  * Extend final [Colors] class to provide more custom app colors.
  */
 data class AppColors(
-    val themeColors: Colors,
+    val themeColors: Colors
 
     // Custom colors here
 )

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppColors.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppColors.kt
@@ -13,17 +13,11 @@ data class AppColors(
 )
 
 internal val LightColorPalette = AppColors(
-    themeColors = lightColors(
-        primary = GreenCitrus,
-        secondary = GreenChristi
-    )
+    themeColors = lightColors()
 )
 
 internal val DarkColorPalette = AppColors(
-    themeColors = darkColors(
-        primary = GreenCitrus,
-        secondary = GreenChristi
-    )
+    themeColors = darkColors()
 )
 
 internal val LocalColors = staticCompositionLocalOf { LightColorPalette }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppColors.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppColors.kt
@@ -2,9 +2,13 @@ package co.nimblehq.template.compose.ui.theme
 
 import androidx.compose.material.*
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+// Base colors here
+internal val GreenCitrus = Color(0xFF99CC00)
 
 /**
- * Extend final [Colors] class to provide more custom app colors.
+ * Expand the final [Colors] class to provide more custom app colors.
  */
 data class AppColors(
     val themeColors: Colors
@@ -20,4 +24,4 @@ internal val DarkColorPalette = AppColors(
     themeColors = darkColors()
 )
 
-internal val LocalColors = staticCompositionLocalOf { LightColorPalette }
+internal val LocalAppColors = staticCompositionLocalOf { LightColorPalette }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppColors.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppColors.kt
@@ -1,4 +1,4 @@
-package co.nimblehq.sample.compose.ui.theme
+package co.nimblehq.template.compose.ui.theme
 
 import androidx.compose.material.*
 import androidx.compose.runtime.staticCompositionLocalOf

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppColors.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppColors.kt
@@ -2,10 +2,9 @@ package co.nimblehq.template.compose.ui.theme
 
 import androidx.compose.material.*
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.graphics.Color
 
 // Base colors here
-internal val GreenCitrus = Color(0xFF99CC00)
+// e.g. internal val GreenCitrus = Color(0xFF99CC00)
 
 /**
  * Expand the final [Colors] class to provide more custom app colors.

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppDimensions.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppDimensions.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.dp
 
 class AppDimensions {
-    // Custom colors here
+    // Custom dimensions here
     val spacingNormal = 16.dp
 }
 

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppDimensions.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppDimensions.kt
@@ -1,0 +1,11 @@
+package co.nimblehq.template.compose.ui.theme
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.dp
+
+class AppDimensions {
+    // Custom colors here
+    val spacingNormal = 16.dp
+}
+
+internal val LocalAppDimensions = staticCompositionLocalOf { AppDimensions() }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppShapes.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppShapes.kt
@@ -1,0 +1,11 @@
+package co.nimblehq.template.compose.ui.theme
+
+import androidx.compose.material.Shapes
+import androidx.compose.material.Typography
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val Shapes = Shapes(
+    // Custom shapes here
+)
+
+internal val LocalAppShapes = staticCompositionLocalOf { Shapes }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppStyles.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppStyles.kt
@@ -1,0 +1,9 @@
+package co.nimblehq.template.compose.ui.theme
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+class AppStyles {
+    // Custom styles here
+}
+
+internal val LocalAppStyles = staticCompositionLocalOf { AppStyles() }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppTypography.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppTypography.kt
@@ -4,7 +4,7 @@ import androidx.compose.material.Typography
 import androidx.compose.runtime.staticCompositionLocalOf
 
 private val Typography = Typography(
-    // Custom TextStyle here
+    // Custom typography here
 )
 
 internal val LocalAppTypography = staticCompositionLocalOf { Typography }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppTypography.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppTypography.kt
@@ -1,0 +1,10 @@
+package co.nimblehq.template.compose.ui.theme
+
+import androidx.compose.material.Typography
+import androidx.compose.runtime.staticCompositionLocalOf
+
+private val Typography = Typography(
+    // Custom TextStyle here
+)
+
+internal val LocalAppTypography = staticCompositionLocalOf { Typography }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Color.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Color.kt
@@ -2,5 +2,5 @@ package co.nimblehq.template.compose.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+// Base colors here
 internal val GreenCitrus = Color(0xFF99CC00)
-internal val GreenChristi = Color(0xFF669900)

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Color.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Color.kt
@@ -1,6 +1,0 @@
-package co.nimblehq.template.compose.ui.theme
-
-import androidx.compose.ui.graphics.Color
-
-// Base colors here
-internal val GreenCitrus = Color(0xFF99CC00)

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Color.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Color.kt
@@ -2,7 +2,5 @@ package co.nimblehq.template.compose.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-object Color {
-    val GreenCitrus = Color(0xFF99CC00)
-    val GreenChristi = Color(0xFF669900)
-}
+internal val GreenCitrus = Color(0xFF99CC00)
+internal val GreenChristi = Color(0xFF669900)

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Dimension.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Dimension.kt
@@ -1,7 +1,0 @@
-package co.nimblehq.template.compose.ui.theme
-
-import androidx.compose.ui.unit.dp
-
-object Dimension {
-    val SpacingNormal = 16.dp
-}

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Theme.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Theme.kt
@@ -14,15 +14,11 @@ fun ComposeTheme(
     } else {
         LightColorPalette
     }
-    val dimensions = LocalAppDimensions.current
-    val styles = LocalAppStyles.current
     val typography = LocalAppTypography.current
     val shapes = LocalAppShapes.current
 
     CompositionLocalProvider(
-        LocalAppColors provides colors,
-        LocalAppDimensions provides dimensions,
-        LocalAppStyles provides styles
+        LocalAppColors provides colors
     ) {
         MaterialTheme(
             colors = colors.themeColors,

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Theme.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Theme.kt
@@ -17,7 +17,7 @@ fun ComposeTheme(
     val dimensions = LocalAppDimensions.current
     val styles = LocalAppStyles.current
     val typography = LocalAppTypography.current
-    val shapes = Shapes()
+    val shapes = LocalAppShapes.current
 
     CompositionLocalProvider(
         LocalAppColors provides colors,
@@ -52,7 +52,7 @@ object AppTheme {
     val shapes: Shapes
         @Composable
         @ReadOnlyComposable
-        get() = MaterialTheme.shapes
+        get() = LocalAppShapes.current
 
     val dimensions: AppDimensions
         @Composable

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Theme.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Theme.kt
@@ -20,7 +20,7 @@ fun ComposeTheme(
     val shapes = Shapes()
 
     CompositionLocalProvider(
-        LocalColors provides colors,
+        LocalAppColors provides colors,
         LocalAppDimensions provides dimensions,
         LocalAppStyles provides styles
     ) {
@@ -42,7 +42,7 @@ object AppTheme {
     val colors: AppColors
         @Composable
         @ReadOnlyComposable
-        get() = LocalColors.current
+        get() = LocalAppColors.current
 
     val typography: Typography
         @Composable

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Theme.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Theme.kt
@@ -64,4 +64,3 @@ object AppTheme {
         @ReadOnlyComposable
         get() = LocalAppStyles.current
 }
-

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Theme.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/Theme.kt
@@ -1,19 +1,67 @@
 package co.nimblehq.template.compose.ui.theme
 
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.lightColors
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.*
+import androidx.compose.runtime.*
 
 @Composable
 fun ComposeTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    MaterialTheme(
-        colors = lightColors(
-            primary = Color.GreenCitrus,
-            primaryVariant = Color.GreenChristi,
-            secondary = Color.GreenCitrus
-        ),
-        content = content
-    )
+    val colors = if (darkTheme) {
+        DarkColorPalette
+    } else {
+        LightColorPalette
+    }
+    val dimensions = LocalAppDimensions.current
+    val styles = LocalAppStyles.current
+    val typography = LocalAppTypography.current
+    val shapes = Shapes()
+
+    CompositionLocalProvider(
+        LocalColors provides colors,
+        LocalAppDimensions provides dimensions,
+        LocalAppStyles provides styles
+    ) {
+        MaterialTheme(
+            colors = colors.themeColors,
+            typography = typography,
+            shapes = shapes,
+            content = content
+        )
+    }
 }
+
+/**
+ * Alternate to [MaterialTheme] allowing us to add our own theme systems
+ * or to extend [MaterialTheme]'s types e.g. return our own [Colors] extension.
+ */
+object AppTheme {
+
+    val colors: AppColors
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalColors.current
+
+    val typography: Typography
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalAppTypography.current
+
+    val shapes: Shapes
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.shapes
+
+    val dimensions: AppDimensions
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalAppDimensions.current
+
+    val styles: AppStyles
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalAppStyles.current
+}
+

--- a/template-compose/app/src/main/res/values/colors.xml
+++ b/template-compose/app/src/main/res/values/colors.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="greenCitrus">#FF99CC00</color>
-    <color name="greenChristi">#FF669900</color>
-</resources>

--- a/template-compose/app/src/main/res/values/styles.xml
+++ b/template-compose/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar"/>
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar" />
 </resources>

--- a/template-compose/app/src/main/res/values/styles.xml
+++ b/template-compose/app/src/main/res/values/styles.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="colorPrimary">@color/greenCitrus</item>
-        <item name="colorPrimaryDark">@color/greenChristi</item>
-        <item name="colorAccent">@color/greenCitrus</item>
-    </style>
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar"/>
 </resources>


### PR DESCRIPTION
- Solves https://github.com/nimblehq/android-templates/issues/353

## What happened 👀

Set up base components for app resources and theme management for Compose template & sample.

- Get rid of using `object class` to define all necessary Color resources in the project. We will [define Color resources as top-level class `val` instead](https://github.com/nimblehq/android-templates/pull/376/files#diff-9bbe79848383e04fde7db80b8136a81e23c4f4cf55e295479cfd6a6b25101196). As discussed, we agreed that using [`object` is not optimized](https://nimble-co.slack.com/archives/G41UCTGHL/p1668064107638629?thread_ts=1668056608.803069&cid=G41UCTGHL).
- Create a new class `AppColors` to define app custom colors instead of having extensions on [Colors](https://github.com/nimblehq/android-templates/pull/376/files#diff-a306e2850925d4734fc257b56fbb1a76fee915082ffe6f911ad65510d5c061cc) class.
- Create a new class `AppDimensions` to define app custom dimensions instead.
- Create a new object `AppTheme` to access app custom resources.

## Insight 📝

- All base colors will be defined in the [`Color`](https://github.com/nimblehq/android-templates/pull/376/files#diff-9bbe79848383e04fde7db80b8136a81e23c4f4cf55e295479cfd6a6b25101196) class as top-level val.
- There are basically two approaches:
  - [1] The naive way is to just create extension properties to hard-code the colors 👉  If we don't want to support multiple themes or light/dark mode this works just fine, just try to not use `object class`.
  - If we want to integrate our colors properly into the theme, we could:
    - [2] using [`staticCompositionLocalOf`](https://developer.android.com/jetpack/compose/compositionlocal), more info [here](https://gustav-karlsson.medium.com/extending-the-jetpack-compose-material-theme-with-more-colors-e1b849390d50).
    - [3] or overriding the `MaterialTheme.colors` by our own `custom Colors` class which contains our custom colors, check out the example [here](https://github.com/android/compose-samples/blob/main/Jetsnack/app/src/main/java/com/example/jetsnack/ui/theme/Theme.kt) 👉 too complex and cumbersome ❌ .

- After investigating, I think the [2] approach looks good. However, we need to have some adjustments:
  - I don't think having an extension `MaterialTheme.myColors` (or another name) and then accessing the colors by `MaterialTheme.myColors.customColor` is really nice. 
  - Instead of accessing custom resources through `MaterialTheme`, having a new custom `AppTheme` object is better in my opinion (more detail [here](https://github.com/android/compose-samples/blob/11ae75b86f15ee5370a87631026697f22e778514/Owl/app/src/main/java/com/example/owl/ui/theme/Theme.kt#L143-L183)).

## Proof Of Work 📹

In the end, we will have:
  - a new [`AppColors`](https://github.com/nimblehq/android-templates/pull/376/files#diff-a306e2850925d4734fc257b56fbb1a76fee915082ffe6f911ad65510d5c061cc) data class that contains `themeColors` to custom `MaterialTheme` base colors.
  - a new [`AppTheme`](https://github.com/nimblehq/android-templates/pull/376/files#diff-25c2cf05d5f277d83a6f9cd73526a6acf41506b09906e00cd06419f5b38469b8) object that reflects `MaterialTheme` and contains our custom resources.
  - to access a color in Composable:
    - referencing to a base color directly .e.g. `color = GreenCitrus` ✅ 
    - referencing to a custom color via `AppTheme.colors`, e.g. `color = AppTheme.colors.GreenCitrus` ✅ 

The app should work properly after refactoring ✅ 

- Template

     <img src="https://user-images.githubusercontent.com/16315358/209658837-27d73b55-37cc-43eb-9ce3-371208841546.png" width=200 />

- Sample

  - Dark theme.
    <img src="https://user-images.githubusercontent.com/16315358/213355610-e5786272-b94a-4cf2-ab2c-9de96e2ba9e2.png" width=200 />

  - Light theme.
    <img src="https://user-images.githubusercontent.com/16315358/213355621-4ee1a147-83ec-4db4-9a60-0ca3ea90639d.png" width=200 />


## References

- [Locally scoped data with CompositionLocal](https://developer.android.com/jetpack/compose/compositionlocal).
- [Android Jetpack Compose: CompositionLocal Made Easy](https://medium.com/mobile-app-development-publication/android-jetpack-compose-compositionlocal-made-easy-8632b201bfcd).
- [compose-samples - Owl](https://github.com/android/compose-samples/blob/11ae75b86f15ee5370a87631026697f22e778514/Owl/app/src/main/java/com/example/owl/ui/theme/Theme.kt#L143-L183).
- [compose-samples - Jetsnack](https://github.com/android/compose-samples/blob/main/Jetsnack/app/src/main/java/com/example/jetsnack/ui/theme/Theme.kt).
- [Extending the Jetpack Compose Material theme with more colors](https://gustav-karlsson.medium.com/extending-the-jetpack-compose-material-theme-with-more-colors-e1b849390d50).
- [Jetpack-Compose-Support-Different-Screen-Size](https://github.com/MakeItEasyDev/Jetpack-Compose-Support-Different-Screen-Size/blob/e70886f23ec86cf571088e220a7f8471bf8754d2/app/src/main/java/com/jetpack/supportdifferentscreensize/ui/theme/Theme.kt#L42-L71).