### PR TITLE
[#373] Update Compose dependecies using BOM version

### DIFF
--- a/sample-compose/app/build.gradle.kts
+++ b/sample-compose/app/build.gradle.kts
@@ -114,13 +114,15 @@ dependencies {
 
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
+    implementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.material:material")
+
     implementation("androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX_VERSION}")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
 
-    implementation("androidx.compose.ui:ui:${Versions.COMPOSE_VERSION}")
-    implementation("androidx.compose.ui:ui-tooling:${Versions.COMPOSE_VERSION}")
-    implementation("androidx.compose.foundation:foundation:${Versions.COMPOSE_VERSION}")
-    implementation("androidx.compose.material:material:${Versions.COMPOSE_VERSION}")
     implementation("androidx.navigation:navigation-compose:${Versions.COMPOSE_NAVIGATION_VERSION}")
 
     implementation("com.google.dagger:hilt-android:${Versions.HILT_VERSION}")

--- a/sample-compose/app/build.gradle.kts
+++ b/sample-compose/app/build.gradle.kts
@@ -114,16 +114,17 @@ dependencies {
 
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
+    implementation("androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX_VERSION}")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
+
     implementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling")
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.material:material")
 
-    implementation("androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX_VERSION}")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
-
     implementation("androidx.navigation:navigation-compose:${Versions.COMPOSE_NAVIGATION_VERSION}")
+    implementation("com.google.accompanist:accompanist-permissions:${Versions.ACCOMPANIST_PERMISSIONS_VERSION}")
 
     implementation("com.google.dagger:hilt-android:${Versions.HILT_VERSION}")
     implementation("androidx.hilt:hilt-navigation-compose:${Versions.HILT_NAVIGATION_COMPOSE_VERSION}")
@@ -134,8 +135,6 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN_VERSION}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.KOTLINX_COROUTINES_VERSION}")
-
-    implementation("com.google.accompanist:accompanist-permissions:${Versions.ACCOMPANIST_PERMISSIONS_VERSION}")
 
     kapt("com.google.dagger:hilt-compiler:${Versions.HILT_VERSION}")
 

--- a/sample-compose/buildSrc/src/main/java/Versions.kt
+++ b/sample-compose/buildSrc/src/main/java/Versions.kt
@@ -16,7 +16,7 @@ object Versions {
     const val ANDROIDX_LIFECYCLE_VERSION = "2.5.1"
 
     const val CHUCKER_VERSION = "3.5.2"
-    const val COMPOSE_VERSION = "1.2.1"
+    const val COMPOSE_BOM_VERSION = "2022.12.00"
     const val COMPOSE_COMPILER_VERSION = "1.3.2"
     const val COMPOSE_NAVIGATION_VERSION = "2.5.1"
 

--- a/template-compose/app/build.gradle.kts
+++ b/template-compose/app/build.gradle.kts
@@ -114,13 +114,15 @@ dependencies {
 
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
+    implementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.material:material")
+
     implementation("androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX_VERSION}")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
 
-    implementation("androidx.compose.ui:ui:${Versions.COMPOSE_VERSION}")
-    implementation("androidx.compose.ui:ui-tooling:${Versions.COMPOSE_VERSION}")
-    implementation("androidx.compose.foundation:foundation:${Versions.COMPOSE_VERSION}")
-    implementation("androidx.compose.material:material:${Versions.COMPOSE_VERSION}")
     implementation("androidx.navigation:navigation-compose:${Versions.COMPOSE_NAVIGATION_VERSION}")
 
     implementation("com.google.dagger:hilt-android:${Versions.HILT_VERSION}")

--- a/template-compose/app/build.gradle.kts
+++ b/template-compose/app/build.gradle.kts
@@ -114,16 +114,17 @@ dependencies {
 
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
 
+    implementation("androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX_VERSION}")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
+
     implementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling")
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.material:material")
 
-    implementation("androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX_VERSION}")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
-
     implementation("androidx.navigation:navigation-compose:${Versions.COMPOSE_NAVIGATION_VERSION}")
+    implementation("com.google.accompanist:accompanist-permissions:${Versions.ACCOMPANIST_PERMISSIONS_VERSION}")
 
     implementation("com.google.dagger:hilt-android:${Versions.HILT_VERSION}")
     implementation("androidx.hilt:hilt-navigation-compose:${Versions.HILT_NAVIGATION_COMPOSE_VERSION}")
@@ -134,8 +135,6 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${Versions.KOTLIN_VERSION}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.KOTLINX_COROUTINES_VERSION}")
-
-    implementation("com.google.accompanist:accompanist-permissions:${Versions.ACCOMPANIST_PERMISSIONS_VERSION}")
 
     kapt("com.google.dagger:hilt-compiler:${Versions.HILT_VERSION}")
 

--- a/template-compose/buildSrc/src/main/java/Versions.kt
+++ b/template-compose/buildSrc/src/main/java/Versions.kt
@@ -16,7 +16,7 @@ object Versions {
     const val ANDROIDX_LIFECYCLE_VERSION = "2.5.1"
 
     const val CHUCKER_VERSION = "3.5.2"
-    const val COMPOSE_VERSION = "1.2.1"
+    const val COMPOSE_BOM_VERSION = "2022.12.00"
     const val COMPOSE_COMPILER_VERSION = "1.3.2"
     const val COMPOSE_NAVIGATION_VERSION = "2.5.1"
 


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/373

## What happened 👀

After Google released [BOM](https://developer.android.com/jetpack/compose/setup#bom-version-mapping) for the compose libraries, it helps us to manage the latest versions of libraries we are using. Therefore, we don't need to handle it independently. However, if we want to fix version to some libraries, we can do it by [overriding the library version](https://developer.android.com/jetpack/compose/setup#how_do_i_use_a_different_library_version_than_whats_designated_in_the_bom).

## Insight 📝

Once we applied `BOM` we can get rid of the specifying version of these libs:
- `androidx.compose.ui:ui`
- `androidx.compose.ui:ui-tooling`
- `androidx.compose.foundation:foundation`
- `androidx.compose.material:material`

But, there're two libs that's relate with `compose`,  but it doesn't type of `BOM`:

- `androidx.navigation:navigation-compose`
- `androidx.hilt:hilt-navigation-compose`

So, Regarding the libs above, we can't include them in `BOM` version.

## Proof Of Work 📹

The app can normally run in both `template-compose` and `sample-compose`.

![Screen Shot 2566-01-10 at 17 14 23](https://user-images.githubusercontent.com/28002315/211528560-0b16bac4-9261-4053-8d47-571074dce7e6.png)

![Screen Shot 2566-01-10 at 17 13 52](https://user-images.githubusercontent.com/28002315/211528404-b184bf0f-c486-4064-a103-f579d8dbe119.png)
