### PR TITLE
[#377] [Compose] Add a sample to navigate to the ThirdScreen with a custom parcelable data

### DIFF
--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/model/UiModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/model/UiModel.kt
@@ -6,8 +6,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class UiModel(
-    val id: String = "",
-    val url: String = "https://www.google.com/"
+    val id: String = ""
 ) : Parcelable
 
 private fun Model.toUiModel() = UiModel(id.toString())

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/model/UiModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/model/UiModel.kt
@@ -6,7 +6,8 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class UiModel(
-    val id: String
+    val id: String = "",
+    val url: String = "https://www.google.com/"
 ) : Parcelable
 
 private fun Model.toUiModel() = UiModel(id.toString())

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/model/UiModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/model/UiModel.kt
@@ -6,7 +6,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class UiModel(
-    val id: String = ""
+    val id: String
 ) : Parcelable
 
 private fun Model.toUiModel() = UiModel(id.toString())

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppDestination.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppDestination.kt
@@ -12,7 +12,7 @@ sealed class AppDestination(val route: String = "") {
 
     open var destination: String = route
 
-    open var parcel: Pair<String, Any?> = "" to null
+    open var parcelableArgument: Pair<String, Any?> = "" to null
 
     object Up : AppDestination()
 
@@ -31,7 +31,7 @@ sealed class AppDestination(val route: String = "") {
 
     object Third : AppDestination("third") {
         fun addParcel(value: UiModel) = apply {
-            parcel = KeyModel to value
+            parcelableArgument = KeyModel to value
         }
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppDestination.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppDestination.kt
@@ -1,14 +1,18 @@
 package co.nimblehq.sample.compose.ui
 
 import androidx.navigation.*
+import co.nimblehq.sample.compose.model.UiModel
 
 const val KeyId = "id"
+const val ModelKey = "model"
 
 sealed class AppDestination(val route: String = "") {
 
     open val arguments: List<NamedNavArgument> = emptyList()
 
     open var destination: String = route
+
+    open var parcel : Pair<String,UiModel?> = "" to null
 
     object Up : AppDestination()
 
@@ -20,8 +24,14 @@ sealed class AppDestination(val route: String = "") {
             navArgument(KeyId) { type = NavType.StringType }
         )
 
-        fun buildDestination(id: String) = apply {
+        fun createRoute(id: String) = apply {
             destination = "second/$id"
+        }
+    }
+
+    object Third: AppDestination("third") {
+        fun addParcel(value: UiModel) = apply {
+            parcel = ModelKey to value
         }
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppDestination.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppDestination.kt
@@ -4,7 +4,7 @@ import androidx.navigation.*
 import co.nimblehq.sample.compose.model.UiModel
 
 const val KeyId = "id"
-const val ModelKey = "model"
+const val KeyModel = "model"
 
 sealed class AppDestination(val route: String = "") {
 
@@ -12,7 +12,7 @@ sealed class AppDestination(val route: String = "") {
 
     open var destination: String = route
 
-    open var parcel : Pair<String,UiModel?> = "" to null
+    open var parcel: Pair<String, Any?> = "" to null
 
     object Up : AppDestination()
 
@@ -29,9 +29,9 @@ sealed class AppDestination(val route: String = "") {
         }
     }
 
-    object Third: AppDestination("third") {
+    object Third : AppDestination("third") {
         fun addParcel(value: UiModel) = apply {
-            parcel = ModelKey to value
+            parcel = KeyModel to value
         }
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavigation.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavigation.kt
@@ -20,7 +20,6 @@ fun AppNavigation(
         composable(destination = AppDestination.Home) {
             HomeScreen(
                 navigator = { destination ->
-//                    navController.navigate(destination)
                     navController.navigate(destination, destination.parcel)
                 }
             )
@@ -36,7 +35,7 @@ fun AppNavigation(
         composable(destination = AppDestination.Third) {
             ThirdScreen(
                 navigator = { destination -> navController.navigate(destination) },
-                model = navController.previousBackStackEntry?.savedStateHandle?.get<UiModel>(ModelKey) ?: UiModel()
+                model = navController.previousBackStackEntry?.savedStateHandle?.get<UiModel>(KeyModel) ?: UiModel()
             )
         }
     }
@@ -66,7 +65,7 @@ private fun <T> NavHostController.navigate(appDestination: AppDestination, parce
     when (appDestination) {
         is AppDestination.Up -> navigateUp()
         else -> {
-            currentBackStackEntry?.savedStateHandle?.set(parcel.first,parcel.second)
+            currentBackStackEntry?.savedStateHandle?.set(parcel.first, parcel.second)
             navigate(route = appDestination.destination)
         }
     }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavigation.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavigation.kt
@@ -20,7 +20,7 @@ fun AppNavigation(
         composable(destination = AppDestination.Home) {
             HomeScreen(
                 navigator = { destination ->
-                    navController.navigate(destination, destination.parcel)
+                    navController.navigate(destination, destination.parcelableArgument)
                 }
             )
         }
@@ -35,7 +35,7 @@ fun AppNavigation(
         composable(destination = AppDestination.Third) {
             ThirdScreen(
                 navigator = { destination -> navController.navigate(destination) },
-                model = navController.previousBackStackEntry?.savedStateHandle?.get<UiModel>(KeyModel) ?: UiModel()
+                model = navController.previousBackStackEntry?.savedStateHandle?.get<UiModel>(KeyModel)
             )
         }
     }
@@ -55,27 +55,19 @@ private fun NavGraphBuilder.composable(
 }
 
 /**
- * Navigate to [AppDestination] with navArgument
- */
-private fun NavHostController.navigate(appDestination: AppDestination) {
-    when (appDestination) {
-        is AppDestination.Up -> navigateUp()
-        else -> navigate(route = appDestination.destination)
-    }
-}
-
-/**
- * Navigate to AppDestination with Parcelable Data
+ * Navigate to provided [AppDestination] with a Pair of key value String and Data [parcel]
  * Caution to use this method. This method use savedStateHandle to store the Parcelable data.
  * When previousBackstackEntry is popped out from navigation stack, savedStateHandle will return null and cannot retrieve data.
  * eg.Login -> Home, the Login screen will be popped from the back-stack on logging in successfully.
- * Navigate to provided [AppDestination] with a Pair of key value String and Data [parcel]
  */
-private fun <T> NavHostController.navigate(appDestination: AppDestination, parcel: Pair<String, T>) {
+private fun NavHostController.navigate(appDestination: AppDestination, parcel: Pair<String, Any?>? = null) {
     when (appDestination) {
         is AppDestination.Up -> navigateUp()
         else -> {
-            currentBackStackEntry?.savedStateHandle?.set(parcel.first, parcel.second)
+            parcel?.let {
+                val (key, value) = it
+                currentBackStackEntry?.savedStateHandle?.set(key, value)
+            }
             navigate(route = appDestination.destination)
         }
     }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavigation.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavigation.kt
@@ -64,8 +64,7 @@ private fun NavHostController.navigate(appDestination: AppDestination, parcel: P
     when (appDestination) {
         is AppDestination.Up -> navigateUp()
         else -> {
-            parcel?.let {
-                val (key, value) = it
+            parcel?.let { (key, value) ->
                 currentBackStackEntry?.savedStateHandle?.set(key, value)
             }
             navigate(route = appDestination.destination)

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavigation.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavigation.kt
@@ -3,8 +3,10 @@ package co.nimblehq.sample.compose.ui
 import androidx.compose.runtime.Composable
 import androidx.navigation.*
 import androidx.navigation.compose.*
+import co.nimblehq.sample.compose.model.UiModel
 import co.nimblehq.sample.compose.ui.screens.home.HomeScreen
 import co.nimblehq.sample.compose.ui.screens.second.SecondScreen
+import co.nimblehq.sample.compose.ui.screens.third.ThirdScreen
 
 @Composable
 fun AppNavigation(
@@ -15,16 +17,26 @@ fun AppNavigation(
         navController = navController,
         startDestination = startDestination
     ) {
-        composable(AppDestination.Home) {
+        composable(destination = AppDestination.Home) {
             HomeScreen(
-                navigator = { destination -> navController.navigate(destination) }
+                navigator = { destination ->
+//                    navController.navigate(destination)
+                    navController.navigate(destination, destination.parcel)
+                }
             )
         }
 
-        composable(AppDestination.Second) { backStackEntry ->
+        composable(destination = AppDestination.Second) { backStackEntry ->
             SecondScreen(
                 navigator = { destination -> navController.navigate(destination) },
                 id = backStackEntry.arguments?.getString(KeyId).orEmpty()
+            )
+        }
+
+        composable(destination = AppDestination.Third) {
+            ThirdScreen(
+                navigator = { destination -> navController.navigate(destination) },
+                model = navController.previousBackStackEntry?.savedStateHandle?.get<UiModel>(ModelKey) ?: UiModel()
             )
         }
     }
@@ -47,5 +59,15 @@ private fun NavHostController.navigate(appDestination: AppDestination) {
     when (appDestination) {
         is AppDestination.Up -> navigateUp()
         else -> navigate(route = appDestination.destination)
+    }
+}
+
+private fun <T> NavHostController.navigate(appDestination: AppDestination, parcel: Pair<String, T>) {
+    when (appDestination) {
+        is AppDestination.Up -> navigateUp()
+        else -> {
+            currentBackStackEntry?.savedStateHandle?.set(parcel.first,parcel.second)
+            navigate(route = appDestination.destination)
+        }
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavigation.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavigation.kt
@@ -54,6 +54,9 @@ private fun NavGraphBuilder.composable(
     )
 }
 
+/**
+ * Navigate to [AppDestination] with navArgument
+ */
 private fun NavHostController.navigate(appDestination: AppDestination) {
     when (appDestination) {
         is AppDestination.Up -> navigateUp()
@@ -61,6 +64,13 @@ private fun NavHostController.navigate(appDestination: AppDestination) {
     }
 }
 
+/**
+ * Navigate to AppDestination with Parcelable Data
+ * Caution to use this method. This method use savedStateHandle to store the Parcelable data.
+ * When previousBackstackEntry is popped out from navigation stack, savedStateHandle will return null and cannot retrieve data.
+ * eg.Login -> Home, the Login screen will be popped from the back-stack on logging in successfully.
+ * Navigate to provided [AppDestination] with a Pair of key value String and Data [parcel]
+ */
 private fun <T> NavHostController.navigate(appDestination: AppDestination, parcel: Pair<String, T>) {
     when (appDestination) {
         is AppDestination.Up -> navigateUp()

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
@@ -44,7 +44,8 @@ fun HomeScreen(
     HomeScreenContent(
         uiModels = uiModels,
         showLoading = showLoading,
-        onItemClick = viewModel::navigateToSecond
+        onItemClick = viewModel::navigateToSecond,
+        onItemEdit = viewModel::navigateToThird
     )
 }
 
@@ -79,7 +80,8 @@ private fun CameraPermission() {
 private fun HomeScreenContent(
     uiModels: List<UiModel>,
     showLoading: IsLoading,
-    onItemClick: (UiModel) -> Unit
+    onItemClick: (UiModel) -> Unit,
+    onItemEdit: (UiModel) -> Unit
 ) {
     Scaffold(topBar = {
         AppBar(R.string.home_title_bar)
@@ -94,7 +96,8 @@ private fun HomeScreenContent(
             } else {
                 ItemList(
                     uiModels = uiModels,
-                    onItemClick = onItemClick
+                    onItemClick = onItemClick,
+                    onItemEdit = onItemEdit
                 )
             }
         }
@@ -108,7 +111,8 @@ private fun HomeScreenPreview() {
         HomeScreenContent(
             uiModels = listOf(UiModel("1"), UiModel("2"), UiModel("3")),
             showLoading = false,
-            onItemClick = {}
+            onItemClick = {},
+            onItemEdit = {}
         )
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
@@ -45,7 +45,7 @@ fun HomeScreen(
         uiModels = uiModels,
         showLoading = showLoading,
         onItemClick = viewModel::navigateToSecond,
-        onItemEdit = viewModel::navigateToThird
+        onItemLongClick = viewModel::navigateToThird
     )
 }
 
@@ -81,7 +81,7 @@ private fun HomeScreenContent(
     uiModels: List<UiModel>,
     showLoading: IsLoading,
     onItemClick: (UiModel) -> Unit,
-    onItemEdit: (UiModel) -> Unit
+    onItemLongClick: (UiModel) -> Unit
 ) {
     Scaffold(topBar = {
         AppBar(R.string.home_title_bar)
@@ -97,7 +97,7 @@ private fun HomeScreenContent(
                 ItemList(
                     uiModels = uiModels,
                     onItemClick = onItemClick,
-                    onItemEdit = onItemEdit
+                    onItemLongClick = onItemLongClick
                 )
             }
         }
@@ -112,7 +112,7 @@ private fun HomeScreenPreview() {
             uiModels = listOf(UiModel("1"), UiModel("2"), UiModel("3")),
             showLoading = false,
             onItemClick = {},
-            onItemEdit = {}
+            onItemLongClick = {}
         )
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
@@ -36,6 +36,10 @@ class HomeViewModel @Inject constructor(
     }
 
     fun navigateToSecond(uiModel: UiModel) {
-        execute { _navigator.emit(AppDestination.Second.buildDestination(uiModel.id)) }
+        execute { _navigator.emit(AppDestination.Second.createRoute(uiModel.id)) }
+    }
+
+    fun navigateToThird(uiModel: UiModel) {
+        execute { _navigator.emit(AppDestination.Third.addParcel(uiModel)) }
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
@@ -31,7 +31,7 @@ fun Item(
     ) {
         Text(
             modifier = Modifier
-                .padding(AppTheme.dimensions.spacingNormal)
+                .padding(dimensions.spacingNormal)
                 .fillMaxWidth(0.8f),
             text = uiModel.id
         )

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
@@ -26,7 +26,7 @@ fun Item(
             .fillMaxWidth()
             .combinedClickable(
                 onClick = { onClick(uiModel) },
-                onLongClick = { expanded = !expanded }
+                onLongClick = { expanded = true }
             )
     ) {
         Text(

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
@@ -40,7 +40,7 @@ fun Item(
             onDismissRequest = { expanded = false }
         ) {
             DropdownMenuItem(onClick = { onLongClick(uiModel) }) {
-                Text(stringResource(id = R.string.third_edit_title))
+                Text(stringResource(id = R.string.third_edit_menu_title))
             }
         }
     }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
@@ -17,7 +17,7 @@ import co.nimblehq.sample.compose.ui.theme.AppTheme.dimensions
 fun Item(
     uiModel: UiModel,
     onClick: (UiModel) -> Unit,
-    onEdit: (UiModel) -> Unit
+    onLongClick: (UiModel) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -39,7 +39,7 @@ fun Item(
             expanded = expanded,
             onDismissRequest = { expanded = false }
         ) {
-            DropdownMenuItem(onClick = { onEdit(uiModel) }) {
+            DropdownMenuItem(onClick = { onLongClick(uiModel) }) {
                 Text(stringResource(id = R.string.third_edit_title))
             }
         }
@@ -53,7 +53,7 @@ private fun ItemPreview() {
         Item(
             uiModel = UiModel("1"),
             onClick = {},
-            onEdit = {}
+            onLongClick = {}
         )
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
@@ -1,29 +1,48 @@
 package co.nimblehq.sample.compose.ui.screens.home
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import co.nimblehq.sample.compose.R
 import co.nimblehq.sample.compose.model.UiModel
+import co.nimblehq.sample.compose.ui.theme.*
 import co.nimblehq.sample.compose.ui.theme.AppTheme.dimensions
-import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun Item(
     uiModel: UiModel,
-    onClick: (UiModel) -> Unit
+    onClick: (UiModel) -> Unit,
+    onEdit: (UiModel) -> Unit
 ) {
-    Row(
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = { onClick(uiModel) })
+            .combinedClickable(
+                onClick = { onClick(uiModel) },
+                onLongClick = { expanded = !expanded }
+            )
     ) {
         Text(
-            modifier = Modifier.padding(dimensions.spacingNormal),
+            modifier = Modifier
+                .padding(AppTheme.dimensions.spacingNormal)
+                .fillMaxWidth(0.8f),
             text = uiModel.id
         )
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            DropdownMenuItem(onClick = { onEdit(uiModel) }) {
+                Text(stringResource(id = R.string.third_edit_title))
+            }
+        }
     }
 }
 
@@ -33,7 +52,8 @@ private fun ItemPreview() {
     ComposeTheme {
         Item(
             uiModel = UiModel("1"),
-            onClick = {}
+            onClick = {},
+            onEdit = {}
         )
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
@@ -12,14 +12,14 @@ import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 fun ItemList(
     uiModels: List<UiModel>,
     onItemClick: (UiModel) -> Unit,
-    onItemEdit: (UiModel) -> Unit
+    onItemLongClick: (UiModel) -> Unit
 ) {
     LazyColumn {
         items(uiModels) { uiModel ->
             Item(
                 uiModel = uiModel,
                 onClick = onItemClick,
-                onEdit = onItemEdit
+                onLongClick = onItemLongClick
             )
             Divider()
         }
@@ -33,7 +33,7 @@ private fun ItemListPreview() {
         ItemList(
             uiModels = listOf(UiModel("1"), UiModel("2"), UiModel("3")),
             onItemClick = {},
-            onItemEdit = {}
+            onItemLongClick = {}
         )
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
@@ -11,13 +11,15 @@ import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 @Composable
 fun ItemList(
     uiModels: List<UiModel>,
-    onItemClick: (UiModel) -> Unit
+    onItemClick: (UiModel) -> Unit,
+    onItemEdit: (UiModel) -> Unit
 ) {
     LazyColumn {
         items(uiModels) { uiModel ->
             Item(
                 uiModel = uiModel,
-                onClick = onItemClick
+                onClick = onItemClick,
+                onEdit = onItemEdit
             )
             Divider()
         }
@@ -30,7 +32,8 @@ private fun ItemListPreview() {
     ComposeTheme {
         ItemList(
             uiModels = listOf(UiModel("1"), UiModel("2"), UiModel("3")),
-            onItemClick = {}
+            onItemClick = {},
+            onItemEdit = {}
         )
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/third/ThirdScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/third/ThirdScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import co.nimblehq.sample.compose.R
 import co.nimblehq.sample.compose.model.UiModel
@@ -21,13 +20,13 @@ import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 fun ThirdScreen(
     viewModel: ThirdViewModel = hiltViewModel(),
     navigator: (destination: AppDestination) -> Unit,
-    model: UiModel
+    model: UiModel?
 ) {
     ThirdScreenContent(data = model)
 }
 
 @Composable
-fun ThirdScreenContent(data: UiModel) {
+fun ThirdScreenContent(data: UiModel?) {
     Scaffold(
         topBar = {
             AppBar(title = R.string.third_title_bar)
@@ -41,9 +40,7 @@ fun ThirdScreenContent(data: UiModel) {
             Text(
                 text = stringResource(R.string.third_data_title, data.toString()),
                 textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(10.dp)
+                modifier = Modifier.align(Alignment.Center)
             )
         }
     }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/third/ThirdScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/third/ThirdScreen.kt
@@ -1,0 +1,58 @@
+package co.nimblehq.sample.compose.ui.screens.third
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import co.nimblehq.sample.compose.R
+import co.nimblehq.sample.compose.model.UiModel
+import co.nimblehq.sample.compose.ui.AppDestination
+import co.nimblehq.sample.compose.ui.screens.AppBar
+import co.nimblehq.sample.compose.ui.theme.ComposeTheme
+
+@Composable
+fun ThirdScreen(
+    viewModel: ThirdViewModel = hiltViewModel(),
+    navigator: (destination: AppDestination) -> Unit,
+    model: UiModel
+) {
+    ThirdScreenContent(data = model)
+}
+
+@Composable
+fun ThirdScreenContent(data: UiModel) {
+    Scaffold(
+        topBar = {
+            AppBar(title = R.string.third_title_bar)
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            Text(
+                text = stringResource(R.string.third_data_title, data.toString()),
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(10.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ThirdScreenPreview() {
+    ComposeTheme {
+        ThirdScreenContent(data = UiModel("1"))
+    }
+}

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/third/ThirdViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/third/ThirdViewModel.kt
@@ -1,0 +1,13 @@
+package co.nimblehq.sample.compose.ui.screens.third
+
+import androidx.lifecycle.SavedStateHandle
+import co.nimblehq.sample.compose.ui.base.BaseViewModel
+import co.nimblehq.sample.compose.util.DispatchersProvider
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ThirdViewModel @Inject constructor(
+    dispatchers: DispatchersProvider,
+    savedStateHandle: SavedStateHandle
+) : BaseViewModel(dispatchers) {}

--- a/sample-compose/app/src/main/res/values/strings.xml
+++ b/sample-compose/app/src/main/res/values/strings.xml
@@ -10,5 +10,5 @@
 
     <string name="third_title_bar">Third</string>
     <string name="third_data_title">Data: %1$s</string>
-    <string name="third_edit_title">Edit</string>
+    <string name="third_edit_menu_title">Edit</string>
 </resources>

--- a/sample-compose/app/src/main/res/values/strings.xml
+++ b/sample-compose/app/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
 
     <string name="second_title_bar">Second</string>
     <string name="second_id_title">ID: %1$s</string>
+
+    <string name="third_title_bar">Third</string>
+    <string name="third_data_title">Data: %1$s</string>
+    <string name="third_edit_title">Edit</string>
 </resources>

--- a/sample-compose/app/src/main/res/values/strings.xml
+++ b/sample-compose/app/src/main/res/values/strings.xml
@@ -9,6 +9,6 @@
     <string name="second_id_title">ID: %1$s</string>
 
     <string name="third_title_bar">Third</string>
-    <string name="third_data_title">Data: %1$s</string>
+    <string name="third_data_title">Data: %s</string>
     <string name="third_edit_menu_title">Edit</string>
 </resources>

--- a/sample-compose/buildSrc/src/main/java/Versions.kt
+++ b/sample-compose/buildSrc/src/main/java/Versions.kt
@@ -18,7 +18,7 @@ object Versions {
     const val CHUCKER_VERSION = "3.5.2"
     const val COMPOSE_BOM_VERSION = "2022.12.00"
     const val COMPOSE_COMPILER_VERSION = "1.3.2"
-    const val COMPOSE_NAVIGATION_VERSION = "2.5.1"
+    const val COMPOSE_NAVIGATION_VERSION = "2.5.3"
 
     const val HILT_VERSION = "2.44"
     const val HILT_NAVIGATION_COMPOSE_VERSION = "1.0.0"


### PR DESCRIPTION
- Closes #377 

## What happened 👀

Coming through [this discussion](https://github.com/nimblehq/android-templates/pull/372#discussion_r1058045844), we need to have a sample implementation to demonstrate how can we pass a parcelable data between destinations. Unfortunately, it's not that easy:
- https://betterprogramming.pub/realize-jetpack-compose-navigation-2889401f52b
- https://stackoverflow.com/questions/65610003/pass-parcelable-argument-with-compose-navigation
- https://stackoverflow.com/questions/67553012/passing-model-between-destinations/67553630#67553630
- https://gist.github.com/Aidanvii7/46f9f014ba4dc58a2ac10625b198769d

We should find an optimized way to apply it to the template.

## Insight 📝

- Tried to implement the way the links provided and I found [this issue](https://github.com/nimblehq/android-templates/issues/377#issuecomment-1379951504)
- Big thanks to Huey's [suggestion](https://github.com/nimblehq/android-templates/issues/377#issuecomment-1381417694), I have successfully implemented to pass a `Parcelable data` between screens 🥳 
- Implemented a `Long Press` behavior and a `DropdownMenu` to be able to go to `Third Screen`
- Used `savedStateHandle` to pass `Parcelable data` between screens
- Updated Compose Navigation Version to `2.5.3` to be able to prove that the current implementation works with the latest version

## Proof Of Work 📹

https://user-images.githubusercontent.com/32578035/212663394-cf53a958-e23e-4960-aa4b-3432726f77c6.mov


