### PR TITLE
[#354] [Compose] 2/2: Add sample UI test with Robolectric

### DIFF
--- a/sample-compose/app/build.gradle.kts
+++ b/sample-compose/app/build.gradle.kts
@@ -162,14 +162,13 @@ dependencies {
     testImplementation("io.mockk:mockk:${Versions.TEST_MOCKK_VERSION}")
     testImplementation("app.cash.turbine:turbine:${Versions.TEST_TURBINE_VERSION}")
 
-    // Instrument test with Robolectric
-    // Need to have BOM for testImplementation https://github.com/gradle/gradle/issues/23347
+    // UI test with Robolectric
     testImplementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
     testImplementation("androidx.compose.ui:ui-test-junit4")
     testImplementation("androidx.test:rules:${Versions.TEST_RULES_VERSION}")
     testImplementation("org.robolectric:robolectric:${Versions.TEST_ROBOLECTRIC_VERSION}")
 
-    // Instrument test
+    // UI test
     androidTestImplementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     androidTestImplementation("androidx.test:rules:${Versions.TEST_RULES_VERSION}")

--- a/sample-compose/app/build.gradle.kts
+++ b/sample-compose/app/build.gradle.kts
@@ -102,6 +102,10 @@ android {
     }
 
     testOptions {
+        unitTests {
+            // Robolectric resource processing/loading https://github.com/robolectric/robolectric/pull/4736
+            isIncludeAndroidResources = true
+        }
         unitTests.all {
             if (it.name != "testStagingDebugUnitTest") {
                 it.extensions.configure(kotlinx.kover.api.KoverTaskExtension::class) {
@@ -157,6 +161,13 @@ dependencies {
     testImplementation("junit:junit:${Versions.TEST_JUNIT_VERSION}")
     testImplementation("io.mockk:mockk:${Versions.TEST_MOCKK_VERSION}")
     testImplementation("app.cash.turbine:turbine:${Versions.TEST_TURBINE_VERSION}")
+
+    // Instrument test with Robolectric
+    // Need to have BOM for testImplementation https://github.com/gradle/gradle/issues/23347
+    testImplementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
+    testImplementation("androidx.compose.ui:ui-test-junit4")
+    testImplementation("androidx.test:rules:${Versions.TEST_RULES_VERSION}")
+    testImplementation("org.robolectric:robolectric:${Versions.TEST_ROBOLECTRIC_VERSION}")
 
     // Instrument test
     androidTestImplementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))

--- a/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -48,19 +48,19 @@ class HomeScreenTest {
     }
 
     @Test
-    fun When_entering_the_Home_screen__it_shows_UI_correctly() = initComposable {
+    fun when_entering_the_Home_screen__it_shows_UI_correctly() = initComposable {
         onNodeWithText("Home").assertIsDisplayed()
     }
 
     @Test
-    fun When_loading_list_item_successfully__it_shows_the_list_item_correctly() = initComposable {
+    fun when_loading_list_item_successfully__it_shows_the_list_item_correctly() = initComposable {
         onNodeWithText("1").assertIsDisplayed()
         onNodeWithText("2").assertIsDisplayed()
         onNodeWithText("3").assertIsDisplayed()
     }
 
     @Test
-    fun When_clicking_on_a_list_item__it_navigates_to_Second_screen() = initComposable {
+    fun when_clicking_on_a_list_item__it_navigates_to_Second_screen() = initComposable {
         onNodeWithText("1").performClick()
 
         assertEquals(expectedAppDestination, AppDestination.Second)

--- a/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -48,19 +48,19 @@ class HomeScreenTest {
     }
 
     @Test
-    fun when_entering_the_Home_screen__it_shows_UI_correctly() = initComposable {
+    fun When_entering_the_Home_screen__it_shows_UI_correctly() = initComposable {
         onNodeWithText("Home").assertIsDisplayed()
     }
 
     @Test
-    fun when_loading_list_item_successfully__it_shows_the_list_item_correctly() = initComposable {
+    fun When_loading_list_item_successfully__it_shows_the_list_item_correctly() = initComposable {
         onNodeWithText("1").assertIsDisplayed()
         onNodeWithText("2").assertIsDisplayed()
         onNodeWithText("3").assertIsDisplayed()
     }
 
     @Test
-    fun when_clicking_on_a_list_item__it_navigates_to_Second_screen() = initComposable {
+    fun When_clicking_on_a_list_item__it_navigates_to_Second_screen() = initComposable {
         onNodeWithText("1").performClick()
 
         assertEquals(expectedAppDestination, AppDestination.Second)

--- a/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -2,8 +2,9 @@ package co.nimblehq.sample.compose.ui.screens.home
 
 import androidx.activity.compose.setContent
 import androidx.compose.ui.test.*
-import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.rule.GrantPermissionRule
 import co.nimblehq.sample.compose.domain.model.Model
 import co.nimblehq.sample.compose.domain.usecase.UseCase
@@ -66,7 +67,9 @@ class HomeScreenTest {
         assertEquals(expectedAppDestination, AppDestination.Second)
     }
 
-    private fun initComposable(testBody: ComposeContentTestRule.() -> Unit) {
+    private fun initComposable(
+        testBody: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>.() -> Unit
+    ) {
         composeRule.activity.setContent {
             ComposeTheme {
                 HomeScreen(

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/base/BaseViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/base/BaseViewModel.kt
@@ -18,8 +18,8 @@ abstract class BaseViewModel(private val dispatchersProvider: DispatchersProvide
     val showLoading: StateFlow<IsLoading>
         get() = _showLoading
 
-    protected val _error = MutableSharedFlow<Throwable>()
-    val error: SharedFlow<Throwable>
+    protected val _error = MutableStateFlow<Throwable?>(null)
+    val error: StateFlow<Throwable?>
         get() = _error
 
     protected val _navigator = MutableSharedFlow<AppDestination>()

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
@@ -19,6 +19,7 @@ import co.nimblehq.sample.compose.ui.screens.AppBar
 import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 import co.nimblehq.sample.compose.ui.userReadableMessage
 import com.google.accompanist.permissions.*
+import kotlinx.coroutines.flow.*
 
 @Composable
 fun HomeScreen(
@@ -26,11 +27,9 @@ fun HomeScreen(
     navigator: (destination: AppDestination) -> Unit
 ) {
     val context = LocalContext.current
-    LaunchedEffect(viewModel.error) {
-        viewModel.error.collect { error ->
-            val message = error.userReadableMessage(context)
-            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-        }
+    val error: Throwable? by viewModel.error.collectAsState()
+    error?.let {
+        Toast.makeText(context, it.userReadableMessage(context), Toast.LENGTH_SHORT).show()
     }
     LaunchedEffect(viewModel.navigator) {
         viewModel.navigator.collect { destination -> navigator(destination) }

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -2,22 +2,28 @@ package co.nimblehq.sample.compose.ui.screens.home
 
 import androidx.activity.compose.setContent
 import androidx.compose.ui.test.*
-import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.rule.GrantPermissionRule
+import co.nimblehq.sample.compose.R
 import co.nimblehq.sample.compose.domain.model.Model
 import co.nimblehq.sample.compose.domain.usecase.UseCase
 import co.nimblehq.sample.compose.test.CoroutineTestRule
 import co.nimblehq.sample.compose.ui.AppDestination
 import co.nimblehq.sample.compose.ui.screens.MainActivity
 import co.nimblehq.sample.compose.ui.theme.ComposeTheme
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.*
 import org.junit.*
 import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowToast
 
 @RunWith(RobolectricTestRunner::class)
 class HomeScreenTest {
@@ -46,22 +52,30 @@ class HomeScreenTest {
             listOf(Model(1), Model(2), Model(3))
         )
 
-        viewModel = HomeViewModel(
-            mockUseCase,
-            coroutinesRule.testDispatcherProvider
-        )
+        initViewModel()
     }
 
     @Test
-    fun `When entering the Home screen, it shows UI correctly`() = initComposable {
-        onNodeWithText("Home").assertIsDisplayed()
-    }
+    fun `When entering the Home screen and loading the list item successfully, it shows the list item correctly`() =
+        initComposable {
+            onNodeWithText("Home").assertIsDisplayed()
+
+            onNodeWithText("1").assertIsDisplayed()
+            onNodeWithText("2").assertIsDisplayed()
+            onNodeWithText("3").assertIsDisplayed()
+        }
 
     @Test
-    fun `When loading list item successfully, it shows the list item correctly`() = initComposable {
-        onNodeWithText("1").assertIsDisplayed()
-        onNodeWithText("2").assertIsDisplayed()
-        onNodeWithText("3").assertIsDisplayed()
+    fun `When entering the Home screen and loading the list item failure, it shows the corresponding error`() {
+        val error = Exception()
+        every { mockUseCase() } returns flow { throw error }
+        initViewModel()
+
+        initComposable {
+            onNodeWithText("Home").assertIsDisplayed()
+
+            ShadowToast.showedToast(activity.getString(R.string.error_generic)) shouldBe true
+        }
     }
 
     @Test
@@ -71,7 +85,9 @@ class HomeScreenTest {
         assertEquals(expectedAppDestination, AppDestination.Second)
     }
 
-    private fun initComposable(testBody: ComposeContentTestRule.() -> Unit) {
+    private fun initComposable(
+        testBody: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>.() -> Unit
+    ) {
         composeRule.activity.setContent {
             ComposeTheme {
                 HomeScreen(
@@ -81,5 +97,12 @@ class HomeScreenTest {
             }
         }
         testBody(composeRule)
+    }
+
+    private fun initViewModel() {
+        viewModel = HomeViewModel(
+            mockUseCase,
+            coroutinesRule.testDispatcherProvider
+        )
     }
 }

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -53,19 +53,19 @@ class HomeScreenTest {
     }
 
     @Test
-    fun `when entering the Home screen, it shows UI correctly`() = initComposable {
+    fun `When entering the Home screen, it shows UI correctly`() = initComposable {
         onNodeWithText("Home").assertIsDisplayed()
     }
 
     @Test
-    fun `when loading list item successfully, it shows the list item correctly`() = initComposable {
+    fun `When loading list item successfully, it shows the list item correctly`() = initComposable {
         onNodeWithText("1").assertIsDisplayed()
         onNodeWithText("2").assertIsDisplayed()
         onNodeWithText("3").assertIsDisplayed()
     }
 
     @Test
-    fun `when clicking on a list item, it navigates to Second screen`() = initComposable {
+    fun `When clicking on a list item, it navigates to Second screen`() = initComposable {
         onNodeWithText("1").performClick()
 
         assertEquals(expectedAppDestination, AppDestination.Second)

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -1,0 +1,85 @@
+package co.nimblehq.sample.compose.ui.screens.home
+
+import androidx.activity.compose.setContent
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.rule.GrantPermissionRule
+import co.nimblehq.sample.compose.domain.model.Model
+import co.nimblehq.sample.compose.domain.usecase.UseCase
+import co.nimblehq.sample.compose.test.CoroutineTestRule
+import co.nimblehq.sample.compose.ui.AppDestination
+import co.nimblehq.sample.compose.ui.screens.MainActivity
+import co.nimblehq.sample.compose.ui.theme.ComposeTheme
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import org.junit.*
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HomeScreenTest {
+
+    private val coroutinesRule = CoroutineTestRule()
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    /**
+     * More test samples with Runtime Permissions https://alexzh.com/ui-testing-of-android-runtime-permissions/
+     */
+    @get:Rule
+    val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        android.Manifest.permission.CAMERA
+    )
+
+    private val mockUseCase: UseCase = mockk()
+
+    private lateinit var viewModel: HomeViewModel
+    private var expectedAppDestination: AppDestination? = null
+
+    @Before
+    fun setup() {
+        every { mockUseCase() } returns flowOf(
+            listOf(Model(1), Model(2), Model(3))
+        )
+
+        viewModel = HomeViewModel(
+            mockUseCase,
+            coroutinesRule.testDispatcherProvider
+        )
+    }
+
+    @Test
+    fun `when entering the Home screen, it shows UI correctly`() = initComposable {
+        onNodeWithText("Home").assertIsDisplayed()
+    }
+
+    @Test
+    fun `when loading list item successfully, it shows the list item correctly`() = initComposable {
+        onNodeWithText("1").assertIsDisplayed()
+        onNodeWithText("2").assertIsDisplayed()
+        onNodeWithText("3").assertIsDisplayed()
+    }
+
+    @Test
+    fun `when clicking on a list item, it navigates to Second screen`() = initComposable {
+        onNodeWithText("1").performClick()
+
+        assertEquals(expectedAppDestination, AppDestination.Second)
+    }
+
+    private fun initComposable(testBody: ComposeContentTestRule.() -> Unit) {
+        composeRule.activity.setContent {
+            ComposeTheme {
+                HomeScreen(
+                    viewModel = viewModel,
+                    navigator = { destination -> expectedAppDestination = destination }
+                )
+            }
+        }
+        testBody(composeRule)
+    }
+}

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -41,7 +41,7 @@ class HomeScreenTest {
     private var expectedAppDestination: AppDestination? = null
 
     @Before
-    fun setup() {
+    fun setUp() {
         every { mockUseCase() } returns flowOf(
             listOf(Model(1), Model(2), Model(3))
         )

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
@@ -36,14 +36,14 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `when loading models successfully, it shows the model list`() = runTest {
+    fun `When loading models successfully, it shows the model list`() = runTest {
         viewModel.uiModels.test {
             expectMostRecentItem() shouldBe models.map { it.toUiModel() }
         }
     }
 
     @Test
-    fun `when loading models failed, it shows the corresponding error`() = runTest {
+    fun `When loading models failed, it shows the corresponding error`() = runTest {
         val error = Exception()
         every { mockUseCase() } returns flow { throw error }
         initViewModel(dispatchers = CoroutineTestRule(StandardTestDispatcher()).testDispatcherProvider)
@@ -67,7 +67,7 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `when calling navigate to Second, it navigates to Second screen`() = runTest {
+    fun `When calling navigate to Second, it navigates to Second screen`() = runTest {
         viewModel.navigator.test {
             viewModel.navigateToSecond(models[0].toUiModel())
 

--- a/sample-compose/app/src/test/resources/robolectric.properties
+++ b/sample-compose/app/src/test/resources/robolectric.properties
@@ -1,0 +1,3 @@
+# Workaround for issue https://github.com/robolectric/robolectric/issues/6593
+instrumentedPackages=androidx.loader.content
+sdk=30

--- a/sample-compose/buildSrc/src/main/java/Versions.kt
+++ b/sample-compose/buildSrc/src/main/java/Versions.kt
@@ -44,6 +44,7 @@ object Versions {
     const val TEST_JUNIT_VERSION = "4.13.2"
     const val TEST_KOTEST_VERSION = "5.5.4"
     const val TEST_MOCKK_VERSION = "1.12.3"
+    const val TEST_ROBOLECTRIC_VERSION = "4.9.2"
     const val TEST_RULES_VERSION = "1.5.0"
     const val TEST_TURBINE_VERSION = "0.12.1"
 }

--- a/template-compose/app/build.gradle.kts
+++ b/template-compose/app/build.gradle.kts
@@ -95,6 +95,10 @@ android {
     }
 
     testOptions {
+        unitTests {
+            // Robolectric resource processing/loading https://github.com/robolectric/robolectric/pull/4736
+            isIncludeAndroidResources = true
+        }
         unitTests.all {
             if (it.name != "testStagingDebugUnitTest") {
                 it.extensions.configure(kotlinx.kover.api.KoverTaskExtension::class) {
@@ -151,7 +155,8 @@ dependencies {
     testImplementation("io.mockk:mockk:${Versions.TEST_MOCKK_VERSION}")
     testImplementation("app.cash.turbine:turbine:${Versions.TEST_TURBINE_VERSION}")
 
-    // Instrument test
-    androidTestImplementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    // UI test with Robolectric
+    testImplementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
+    testImplementation("androidx.compose.ui:ui-test-junit4")
+    testImplementation("org.robolectric:robolectric:${Versions.TEST_ROBOLECTRIC_VERSION}")
 }

--- a/template-compose/app/src/androidTest/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
+++ b/template-compose/app/src/androidTest/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
@@ -26,7 +26,7 @@ class HomeScreenTest {
     }
 
     @Test
-    fun when_entering_the_Home_screen__it_shows_UI_correctly() {
+    fun When_entering_the_Home_screen__it_shows_UI_correctly() {
         composeRule.run {
             onNodeWithText(activity.getString(R.string.app_name)).assertIsDisplayed()
         }

--- a/template-compose/app/src/androidTest/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
+++ b/template-compose/app/src/androidTest/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
@@ -26,7 +26,7 @@ class HomeScreenTest {
     }
 
     @Test
-    fun When_entering_the_Home_screen__it_shows_UI_correctly() {
+    fun when_entering_the_Home_screen__it_shows_UI_correctly() {
         composeRule.run {
             onNodeWithText(activity.getString(R.string.app_name)).assertIsDisplayed()
         }

--- a/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
+++ b/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
@@ -1,12 +1,13 @@
 package co.nimblehq.template.compose.ui.screens.home
 
 import androidx.activity.compose.setContent
-import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.*
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import co.nimblehq.template.compose.R
 import co.nimblehq.template.compose.ui.AppDestination
 import co.nimblehq.template.compose.ui.screens.MainActivity
+import co.nimblehq.template.compose.ui.theme.ComposeTheme
 import org.junit.*
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -21,17 +22,24 @@ class HomeScreenTest {
 
     @Before
     fun setUp() {
-        composeRule.activity.setContent {
-            HomeScreen(
-                navigator = { destination -> expectedAppDestination = destination }
-            )
-        }
+        // TODO more setup logic here
     }
 
     @Test
-    fun `When entering the Home screen, it shows UI correctly`() {
-        composeRule.run {
-            onNodeWithText(activity.getString(R.string.app_name)).assertIsDisplayed()
+    fun `When entering the Home screen, it shows UI correctly`() = initComposable {
+        onNodeWithText(activity.getString(R.string.app_name)).assertIsDisplayed()
+    }
+
+    private fun initComposable(
+        testBody: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>.() -> Unit
+    ) {
+        composeRule.activity.setContent {
+            ComposeTheme {
+                HomeScreen(
+                    navigator = { destination -> expectedAppDestination = destination }
+                )
+            }
         }
+        testBody(composeRule)
     }
 }

--- a/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
+++ b/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
@@ -8,7 +8,10 @@ import co.nimblehq.template.compose.R
 import co.nimblehq.template.compose.ui.AppDestination
 import co.nimblehq.template.compose.ui.screens.MainActivity
 import org.junit.*
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class HomeScreenTest {
 
     @get:Rule
@@ -26,7 +29,7 @@ class HomeScreenTest {
     }
 
     @Test
-    fun when_entering_the_Home_screen__it_shows_UI_correctly() {
+    fun `When entering the Home screen, it shows UI correctly`() {
         composeRule.run {
             onNodeWithText(activity.getString(R.string.app_name)).assertIsDisplayed()
         }

--- a/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModelTest.kt
+++ b/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModelTest.kt
@@ -35,14 +35,14 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `when loading models successfully, it shows the model list`() = runTest {
+    fun `When loading models successfully, it shows the model list`() = runTest {
         viewModel.uiModels.test {
             expectMostRecentItem() shouldBe models.map { it.toUiModel() }
         }
     }
 
     @Test
-    fun `when loading models failed, it shows the corresponding error`() = runTest {
+    fun `When loading models failed, it shows the corresponding error`() = runTest {
         val error = Exception()
         every { mockUseCase() } returns flow { throw error }
         initViewModel(dispatchers = CoroutineTestRule(StandardTestDispatcher()).testDispatcherProvider)

--- a/template-compose/app/src/test/resources/robolectric.properties
+++ b/template-compose/app/src/test/resources/robolectric.properties
@@ -1,0 +1,3 @@
+# Workaround for issue https://github.com/robolectric/robolectric/issues/6593
+instrumentedPackages=androidx.loader.content
+sdk=30

--- a/template-compose/buildSrc/src/main/java/Versions.kt
+++ b/template-compose/buildSrc/src/main/java/Versions.kt
@@ -44,5 +44,6 @@ object Versions {
     const val TEST_JUNIT_VERSION = "4.13.2"
     const val TEST_KOTEST_VERSION = "4.6.3"
     const val TEST_MOCKK_VERSION = "1.13.3"
+    const val TEST_ROBOLECTRIC_VERSION = "4.9.2"
     const val TEST_TURBINE_VERSION = "0.12.1"
 }


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/354

## What happened 👀

- Add a sample for writing UI test with Robolectric as unit test instead of an Instrument test.
- Set up running UI tests with Robolectric as default for the `template` project.

## Insight 📝

- Add `org.robolectric:robolectric` dependency in testImplementation.
- Add `androidx.compose.ui:ui-test-junit4` for Compose UI test and `androidx.test:rules` for permission granting.
- Clone `HomeScreenTest` from `androidTest` folder into `test` with replacing `@RunWith(AndroidJUnit4::class)` by `@RunWith(RobolectricTestRunner::class)`. Now our HomeScreenTest can run with Robolectric as unit test instead of an Instrument test ✅ 

## Proof Of Work 📹

All unit tests passed ✅ 

![image](https://user-images.githubusercontent.com/16315358/216781892-189ebf4e-46fa-44e4-abe9-76e276982e56.png)

Kover now can report code coverage for `HomeScreen` ✅ 

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/16315358/216781921-6337ad40-853a-4549-bef5-0ad2dd60f084.png">



