### PR TITLE
[#394] Fix bump version workflow

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -19,17 +19,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bump version script
-        id: set_version
         run: |
           perl -i -pe 's/^(templateScriptVersion=(.*))$/"templateScriptVersion=${{ github.event.inputs.newVersion }}"/e' version.properties
 
       - name: Bump version XML
-        id: set_version_xml
         run: |
           perl -i -pe 's/ANDROID_VERSION_NAME =(.*)$/ANDROID_VERSION_NAME = "${{ github.event.inputs.newVersion }}"/g' sample-xml/buildSrc/src/main/java/Versions.kt
 
       - name: Bump version Compose
-        id: set_version_compose
         run: |
           perl -i -pe 's/ANDROID_VERSION_NAME =(.*)$/ANDROID_VERSION_NAME = "${{ github.event.inputs.newVersion }}"/g' sample-compose/buildSrc/src/main/java/Versions.kt
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -26,12 +26,12 @@ jobs:
       - name: Bump version XML
         id: set_version_xml
         run: |
-          perl -i -pe 's/^(ANDROID_VERSION_NAME = (.*))$/"ANDROID_VERSION_NAME = ${{ github.event.inputs.newVersion }}"/e' sample-xml/buildSrc/src/main/java/Versions.kt
+          perl -i -pe 's/ANDROID_VERSION_NAME =(.*)$/ANDROID_VERSION_NAME = "${{ github.event.inputs.newVersion }}"/g' sample-xml/buildSrc/src/main/java/Versions.kt
 
       - name: Bump version Compose
         id: set_version_compose
         run: |
-          perl -i -pe 's/^(ANDROID_VERSION_NAME = (.*))$/"ANDROID_VERSION_NAME = ${{ github.event.inputs.newVersion }}"/e' sample-compose/buildSrc/src/main/java/Versions.kt
+          perl -i -pe 's/ANDROID_VERSION_NAME =(.*)$/ANDROID_VERSION_NAME = "${{ github.event.inputs.newVersion }}"/g' sample-compose/buildSrc/src/main/java/Versions.kt
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -24,16 +24,14 @@ jobs:
           perl -i -pe 's/^(templateScriptVersion=(.*))$/"templateScriptVersion=${{ github.event.inputs.newVersion }}"/e' version.properties
 
       - name: Bump version XML
-        uses: chkfung/android-version-actions@v1.2.1
-        with:
-          gradlePath: sample-xml/app/build.gradle.kts
-          versionName: ${{ github.event.inputs.newVersion }}
+        id: set_version_xml
+        run: |
+          perl -i -pe 's/^(ANDROID_VERSION_NAME = (.*))$/"ANDROID_VERSION_NAME = ${{ github.event.inputs.newVersion }}"/e' sample-xml/buildSrc/src/main/java/Versions.kt
 
       - name: Bump version Compose
-        uses: chkfung/android-version-actions@v1.2.1
-        with:
-          gradlePath: sample-compose/app/build.gradle.kts
-          versionName: ${{ github.event.inputs.newVersion }}
+        id: set_version_compose
+        run: |
+          perl -i -pe 's/^(ANDROID_VERSION_NAME = (.*))$/"ANDROID_VERSION_NAME = ${{ github.event.inputs.newVersion }}"/e' sample-compose/buildSrc/src/main/java/Versions.kt
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
Close https://github.com/nimblehq/android-templates/issues/394

## What happened 👀

Replace the version name of the variable instead of changing it directly in bundle files

## Insight 📝

- Replace `ANDROID_VERSION_NAME` variable with the new value, by using `Perl` command

## Proof Of Work 📹

https://github.com/nimblehq/android-templates/pull/402
