### PR TITLE
[#405] Fix: Missing Detekt's rule TopLevelPropertyNaming > privatePropertyPattern for Jetpack Compose

### DIFF
--- a/sample-compose/detekt-config.yml
+++ b/sample-compose/detekt-config.yml
@@ -205,7 +205,7 @@ naming:
     active: true
     constantPattern: '[A-Z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][A-Za-z0-9]*'
-    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][A-Za-z0-9]*'
   VariableMaxLength:
     active: false
     maximumVariableNameLength: 64

--- a/template-compose/detekt-config.yml
+++ b/template-compose/detekt-config.yml
@@ -205,7 +205,7 @@ naming:
     active: true
     constantPattern: '[A-Z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][A-Za-z0-9]*'
-    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][A-Za-z0-9]*'
   VariableMaxLength:
     active: false
     maximumVariableNameLength: 64


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/405

## What happened 👀

Detekt is reporting `TopLevelPropertyNaming` issue for private val which includes capitalizing the first letter:
https://github.com/nimblehq/android-templates/blob/e6380e2b5ea86391d1de11f8e09122a865c85d7f/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppShapes.kt#L7-L9
https://github.com/nimblehq/android-templates/blob/e6380e2b5ea86391d1de11f8e09122a865c85d7f/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppTypography.kt#L6-L8

<img width="1622" alt="image" src="https://user-images.githubusercontent.com/16315358/217891147-57a84ee4-abfb-4e96-ba43-5d081eaee5c6.png">

## Insight 📝

Update privatePropertyPattern from `'(_)?[a-z][A-Za-z0-9]*'` -> `'(_)?[A-Za-z][A-Za-z0-9]*'` in both  `template/sample-compose`.

## Proof Of Work 📹
![template_fixed](https://user-images.githubusercontent.com/28002315/221463860-fbfd9bab-1f90-4368-81cf-03acd391b525.png)

![sample_fixed](https://user-images.githubusercontent.com/28002315/221463867-9e636e64-658c-4450-8636-4d90e5b8c17a.png)

