### PR TITLE
[#410] Update collectAsState to collectAsStateWithLifecyle for observing flow in Android lifecycle manner

### DIFF
--- a/sample-compose/app/build.gradle.kts
+++ b/sample-compose/app/build.gradle.kts
@@ -130,6 +130,7 @@ dependencies {
 
     implementation("androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX_VERSION}")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
 
     implementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
     implementation("androidx.compose.ui:ui")

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.nimblehq.sample.compose.R
 import co.nimblehq.sample.compose.lib.IsLoading
 import co.nimblehq.sample.compose.model.UiModel
@@ -26,12 +27,12 @@ fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel(),
     navigator: (destination: AppDestination) -> Unit
 ) {
-    val isLoading: IsLoading by viewModel.isLoading.collectAsState()
-    val uiModels: List<UiModel> by viewModel.uiModels.collectAsState()
-    val isFirstTimeLaunch: Boolean by viewModel.isFirstTimeLaunch.collectAsState()
+    val isLoading: IsLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val uiModels: List<UiModel> by viewModel.uiModels.collectAsStateWithLifecycle()
+    val isFirstTimeLaunch: Boolean by viewModel.isFirstTimeLaunch.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
-    val error: Throwable? by viewModel.error.collectAsState()
+    val error: Throwable? by viewModel.error.collectAsStateWithLifecycle()
     error?.let {
         Toast.makeText(context, it.userReadableMessage(context), Toast.LENGTH_SHORT).show()
     }

--- a/sample-compose/buildSrc/src/main/java/Versions.kt
+++ b/sample-compose/buildSrc/src/main/java/Versions.kt
@@ -14,12 +14,12 @@ object Versions {
     const val ANDROID_CRYPTO_VERSION = "1.0.0"
     const val ANDROIDX_CORE_KTX_VERSION = "1.9.0"
     const val ANDROIDX_DATASTORE_PREFERENCES_VERSION = "1.0.0"
-    const val ANDROIDX_LIFECYCLE_VERSION = "2.5.1"
+    const val ANDROIDX_LIFECYCLE_VERSION = "2.6.0-rc01"
     const val ANDROIDX_TEST_CORE_VERSION = "1.4.0"
 
     const val CHUCKER_VERSION = "3.5.2"
     const val COMPOSE_BOM_VERSION = "2022.12.00"
-    const val COMPOSE_COMPILER_VERSION = "1.3.2"
+    const val COMPOSE_COMPILER_VERSION = "1.4.3"
     const val COMPOSE_NAVIGATION_VERSION = "2.5.3"
 
     const val HILT_VERSION = "2.44"
@@ -27,7 +27,7 @@ object Versions {
 
     const val JAVAX_INJECT_VERSION = "1"
 
-    const val KOTLIN_VERSION = "1.7.20"
+    const val KOTLIN_VERSION = "1.8.10"
     const val KOTLINX_COROUTINES_VERSION = "1.6.4"
     const val KOVER_VERSION = "0.6.0"
 
@@ -48,6 +48,5 @@ object Versions {
     const val TEST_MOCKK_VERSION = "1.12.3"
     const val TEST_ROBOLECTRIC_VERSION = "4.9.2"
     const val TEST_RULES_VERSION = "1.5.0"
-    const val TEST_ROBOLECTRIC_VERSION = "4.8.2"
     const val TEST_TURBINE_VERSION = "0.12.1"
 }

--- a/template-compose/app/build.gradle.kts
+++ b/template-compose/app/build.gradle.kts
@@ -123,6 +123,7 @@ dependencies {
 
     implementation("androidx.core:core-ktx:${Versions.ANDROIDX_CORE_KTX_VERSION}")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:${Versions.ANDROIDX_LIFECYCLE_VERSION}")
 
     implementation(platform("androidx.compose:compose-bom:${Versions.COMPOSE_BOM_VERSION}"))
     implementation("androidx.compose.ui:ui")

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeScreen.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeScreen.kt
@@ -2,12 +2,14 @@ package co.nimblehq.template.compose.ui.screens.home
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.nimblehq.template.compose.R
 import co.nimblehq.template.compose.model.UiModel
 import co.nimblehq.template.compose.ui.AppDestination
@@ -20,7 +22,7 @@ fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel(),
     navigator: (destination: AppDestination) -> Unit
 ) {
-    val uiModels: List<UiModel> by viewModel.uiModels.collectAsState()
+    val uiModels: List<UiModel> by viewModel.uiModels.collectAsStateWithLifecycle()
 
     HomeScreenContent(
         title = stringResource(id = R.string.app_name),

--- a/template-compose/buildSrc/src/main/java/Versions.kt
+++ b/template-compose/buildSrc/src/main/java/Versions.kt
@@ -14,12 +14,12 @@ object Versions {
     const val ANDROID_CRYPTO_VERSION = "1.0.0"
     const val ANDROIDX_CORE_KTX_VERSION = "1.9.0"
     const val ANDROIDX_DATASTORE_PREFERENCES_VERSION = "1.0.0"
-    const val ANDROIDX_LIFECYCLE_VERSION = "2.5.1"
+    const val ANDROIDX_LIFECYCLE_VERSION = "2.6.0-rc01"
     const val ANDROIDX_TEST_CORE_VERSION = "1.4.0"
 
     const val CHUCKER_VERSION = "3.5.2"
     const val COMPOSE_BOM_VERSION = "2022.12.00"
-    const val COMPOSE_COMPILER_VERSION = "1.3.2"
+    const val COMPOSE_COMPILER_VERSION = "1.4.3"
     const val COMPOSE_NAVIGATION_VERSION = "2.5.3"
 
     const val HILT_VERSION = "2.44"
@@ -27,7 +27,7 @@ object Versions {
 
     const val JAVAX_INJECT_VERSION = "1"
 
-    const val KOTLIN_VERSION = "1.7.20"
+    const val KOTLIN_VERSION = "1.8.10"
     const val KOTLINX_COROUTINES_VERSION = "1.6.4"
     const val KOVER_VERSION = "0.6.0"
 


### PR DESCRIPTION
- Closes #410 

## What happened 👀

- Add dependency `androidx.lifecycle:lifecycle-runtime-compose` to use `collectAsStateWithLifeCycle()`
- Replace `collectAsState()` to `collectAsStateWithLifeCycle()` in `HomeScreen`

## Insight 📝

To use `androidx.lifecycle:lifecycle-runtime-compose` version `2.6.0-rc01`, we need to update the following libs versions:
- **androidx.lifecycle:lifecycle-runtime-ktx** from `2.5.1` to `2.6.0-rc01` to use the same version for lifecycle lib
- **kotlin version** from `1.7.20` to `1.8.10`
- **compose compiler version** from `1.3.2` to `1.4.3`

## Proof Of Work 📹

<details>
  <summary>Template Compose</summary>
  
  [template-compose.webm](https://user-images.githubusercontent.com/12026942/222374629-88186296-4d5e-44a8-8583-a5a8dfec7e29.webm)

</details>

<details>
  <summary>Sample Compose</summary>
  
  [sample-compose.webm](https://user-images.githubusercontent.com/12026942/222374697-079060c1-9025-462f-b3ec-20dc8ac819bf.webm)

</details>
