### PR TITLE
[#415] [Chore] Update dependency injection implementation for the DataStore from the delegate pattern to the builder pattern

### DIFF
--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/di/modules/PreferencesModule.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/di/modules/PreferencesModule.kt
@@ -2,14 +2,18 @@ package co.nimblehq.sample.compose.di.modules
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.preferencesDataStoreFile
 import co.nimblehq.sample.compose.data.repository.AppPreferencesRepositoryImpl
 import co.nimblehq.sample.compose.domain.repository.AppPreferencesRepository
 import dagger.*
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private const val APP_PREFERENCES = "app_preferences"
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -21,11 +25,14 @@ abstract class PreferencesModule {
     ): AppPreferencesRepository
 
     companion object {
-        private val Context.appPreferencesDataStore by preferencesDataStore("app_preferences")
-
+        @Singleton
         @Provides
         fun provideAppPreferencesDataStore(
-            @ApplicationContext applicationContext: Context
-        ): DataStore<Preferences> = applicationContext.appPreferencesDataStore
+            @ApplicationContext appContext: Context
+        ): DataStore<Preferences> {
+            return PreferenceDataStoreFactory.create(
+                produceFile = { appContext.preferencesDataStoreFile(APP_PREFERENCES) }
+            )
+        }
     }
 }

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/di/modules/PreferencesModule.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/di/modules/PreferencesModule.kt
@@ -2,8 +2,9 @@ package co.nimblehq.sample.xml.di.modules
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.preferencesDataStoreFile
 import co.nimblehq.sample.xml.data.repository.AppPreferencesRepositoryImpl
 import co.nimblehq.sample.xml.domain.repository.AppPreferencesRepository
 import dagger.*
@@ -11,6 +12,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
+
+private const val APP_PREFERENCES = "app_preferences"
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -22,11 +25,14 @@ abstract class PreferencesModule {
     ): AppPreferencesRepository
 
     companion object {
-        private val Context.appPreferencesDataStore by preferencesDataStore("app_preferences")
-
+        @Singleton
         @Provides
         fun provideAppPreferencesDataStore(
-            @ApplicationContext applicationContext: Context
-        ): DataStore<Preferences> = applicationContext.appPreferencesDataStore
+            @ApplicationContext appContext: Context
+        ): DataStore<Preferences> {
+            return PreferenceDataStoreFactory.create(
+                produceFile = { appContext.preferencesDataStoreFile(APP_PREFERENCES) }
+            )
+        }
     }
 }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/di/modules/PreferencesModule.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/di/modules/PreferencesModule.kt
@@ -2,14 +2,18 @@ package co.nimblehq.template.compose.di.modules
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.preferencesDataStoreFile
 import co.nimblehq.template.compose.data.repository.AppPreferencesRepositoryImpl
 import co.nimblehq.template.compose.domain.repository.AppPreferencesRepository
 import dagger.*
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private const val APP_PREFERENCES = "app_preferences"
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -21,11 +25,14 @@ abstract class PreferencesModule {
     ): AppPreferencesRepository
 
     companion object {
-        private val Context.appPreferencesDataStore by preferencesDataStore("app_preferences")
-
+        @Singleton
         @Provides
         fun provideAppPreferencesDataStore(
-            @ApplicationContext applicationContext: Context
-        ): DataStore<Preferences> = applicationContext.appPreferencesDataStore
+            @ApplicationContext appContext: Context
+        ): DataStore<Preferences> {
+            return PreferenceDataStoreFactory.create(
+                produceFile = { appContext.preferencesDataStoreFile(APP_PREFERENCES) }
+            )
+        }
     }
 }

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/di/modules/PreferencesModule.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/di/modules/PreferencesModule.kt
@@ -2,8 +2,9 @@ package co.nimblehq.template.xml.di.modules
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStore
+import androidx.datastore.preferences.preferencesDataStoreFile
 import co.nimblehq.template.xml.data.repository.AppPreferencesRepositoryImpl
 import co.nimblehq.template.xml.domain.repository.AppPreferencesRepository
 import dagger.*
@@ -11,6 +12,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
+
+private const val APP_PREFERENCES = "app_preferences"
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -22,11 +25,14 @@ abstract class PreferencesModule {
     ): AppPreferencesRepository
 
     companion object {
-        private val Context.appPreferencesDataStore by preferencesDataStore("app_preferences")
-
+        @Singleton
         @Provides
         fun provideAppPreferencesDataStore(
-            @ApplicationContext applicationContext: Context
-        ): DataStore<Preferences> = applicationContext.appPreferencesDataStore
+            @ApplicationContext appContext: Context
+        ): DataStore<Preferences> {
+            return PreferenceDataStoreFactory.create(
+                produceFile = { appContext.preferencesDataStoreFile(APP_PREFERENCES) }
+            )
+        }
     }
 }


### PR DESCRIPTION
- Closes #415 

## What happened 👀

Update dependency injection of DataStore to use builder pattern for sample-compose, sample-xml, template-xml and template-compose

## Insight 📝

Update providing DataStore dependency using [latest builder pattern](https://medium.com/androiddevelopers/datastore-and-dependency-injection-ea32b95704e3).

`PreferenceDataStoreFactory` accept 3 optional parameters and 1 mandatory parameter.
- `corruptionHandler` (optional) — invoked if a `CorruptionException` is thrown by the serializer when the data cannot be de-serialized which instructs DataStore how to replace the corrupted data
- `migrations` (optional) — a list of `DataMigration` for moving previous data into DataStore
- `scope` (optional) — the scope in which IO operations and transform functions will execute
- `produceFile` — generates the `File` object for Preferences DataStore based on the provided `Context` and `name`, stored in `this.applicationContext.filesDir` + `datastore/` subdirectory

I have only implemented using the mandatory one since we don't need the others for now.

## Proof Of Work 📹

### sample-compose
https://user-images.githubusercontent.com/32578035/223601820-1ac5a72c-49be-4e13-9e3b-667aedf32b7a.mov

### sample-xml

https://user-images.githubusercontent.com/32578035/223607625-12cf3cb4-22ca-4fac-a4a0-26ed9ec42d81.mov



