### PR TITLE
[#426] [Kotlin Flow] Refactor `try/catch` to `runCatching { ... }`

### DIFF
--- a/sample-compose/data/src/main/java/co/nimblehq/sample/compose/data/extensions/ResponseMapping.kt
+++ b/sample-compose/data/src/main/java/co/nimblehq/sample/compose/data/extensions/ResponseMapping.kt
@@ -15,15 +15,11 @@ import java.io.InterruptedIOException
 import java.net.UnknownHostException
 import kotlin.experimental.ExperimentalTypeInference
 
-@Suppress("TooGenericExceptionCaught")
 @OptIn(ExperimentalTypeInference::class)
 fun <T> flowTransform(@BuilderInference block: suspend FlowCollector<T>.() -> T) = flow {
-    val result = try {
-        block()
-    } catch (exception: Exception) {
-        throw exception.mapError()
-    }
-    emit(result)
+    runCatching { block() }
+        .onSuccess { result -> emit(result) }
+        .onFailure { exception -> throw exception.mapError() }
 }
 
 private fun Throwable.mapError(): Throwable {

--- a/sample-xml/data/src/main/java/co/nimblehq/sample/xml/data/extensions/ResponseMapping.kt
+++ b/sample-xml/data/src/main/java/co/nimblehq/sample/xml/data/extensions/ResponseMapping.kt
@@ -15,15 +15,11 @@ import java.io.InterruptedIOException
 import java.net.UnknownHostException
 import kotlin.experimental.ExperimentalTypeInference
 
-@Suppress("TooGenericExceptionCaught")
 @OptIn(ExperimentalTypeInference::class)
 fun <T> flowTransform(@BuilderInference block: suspend FlowCollector<T>.() -> T) = flow {
-    val result = try {
-        block()
-    } catch (exception: Exception) {
-        throw exception.mapError()
-    }
-    emit(result)
+    runCatching { block() }
+        .onSuccess { result -> emit(result) }
+        .onFailure { exception -> throw exception.mapError() }
 }
 
 private fun Throwable.mapError(): Throwable {

--- a/template-compose/data/src/main/java/co/nimblehq/template/compose/data/extensions/ResponseMapping.kt
+++ b/template-compose/data/src/main/java/co/nimblehq/template/compose/data/extensions/ResponseMapping.kt
@@ -15,15 +15,11 @@ import java.io.InterruptedIOException
 import java.net.UnknownHostException
 import kotlin.experimental.ExperimentalTypeInference
 
-@Suppress("TooGenericExceptionCaught")
 @OptIn(ExperimentalTypeInference::class)
 fun <T> flowTransform(@BuilderInference block: suspend FlowCollector<T>.() -> T) = flow {
-    val result = try {
-        block()
-    } catch (exception: Exception) {
-        throw exception.mapError()
-    }
-    emit(result)
+    runCatching { block() }
+        .onSuccess { result -> emit(result) }
+        .onFailure { exception -> throw exception.mapError() }
 }
 
 private fun Throwable.mapError(): Throwable {

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/extensions/ResponseMapping.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/extensions/ResponseMapping.kt
@@ -15,15 +15,11 @@ import java.io.InterruptedIOException
 import java.net.UnknownHostException
 import kotlin.experimental.ExperimentalTypeInference
 
-@Suppress("TooGenericExceptionCaught")
 @OptIn(ExperimentalTypeInference::class)
 fun <T> flowTransform(@BuilderInference block: suspend FlowCollector<T>.() -> T) = flow {
-    val result = try {
-        block()
-    } catch (exception: Exception) {
-        throw exception.mapError()
-    }
-    emit(result)
+    runCatching { block() }
+        .onSuccess { result -> emit(result) }
+        .onFailure { exception -> throw exception.mapError() }
 }
 
 private fun Throwable.mapError(): Throwable {


### PR DESCRIPTION
Closes #426 

## What happened 👀

- Simple refactor from `try/catch` to `runCatching { ... }`
- Remove redundant annotation

## Proof Of Work 📹

All tests are successful and the app is still working correctly
