### PR TITLE
[#443] Fix: Missing additional use-cases mocking and tests verifying steps in CI for sample-xml & sample-compose

### DIFF
--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -30,6 +30,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      # template-xml
+
       - name: Run Detekt on template-xml
         working-directory: ./template-xml
         run: ./gradlew detekt
@@ -41,6 +43,8 @@ jobs:
       - name: Run unit tests with Kover on template-xml
         working-directory: ./template-xml
         run: ./gradlew koverMergedXmlReport
+
+      # template-compose
 
       - name: Run Detekt on template-compose
         working-directory: ./template-compose

--- a/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.github/workflows/run_detekt_and_unit_tests.yml
@@ -28,6 +28,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      # template-xml
+
       - name: Run Detekt on template-xml
         working-directory: ./template-xml
         run: ./gradlew detekt
@@ -48,6 +50,8 @@ jobs:
           name: CodeCoverageReportsTemplateXML
           path: template-xml/build/reports/kover/merged/
 
+      # template-compose
+
       - name: Run Detekt on template-compose
         working-directory: ./template-compose
         run: ./gradlew detekt
@@ -67,3 +71,47 @@ jobs:
         with:
           name: CodeCoverageReportsTemplateCompose
           path: template-compose/build/reports/kover/merged/
+
+      # sample-xml
+
+      - name: Run Detekt on sample-xml
+        working-directory: ./sample-xml
+        run: ./gradlew detekt
+
+      - name: Archive Detekt reports on sample-xml
+        uses: actions/upload-artifact@v2
+        with:
+          name: DetektReportsTemplateXML
+          path: sample-xml/build/reports/detekt/
+
+      - name: Run unit tests with Kover on sample-xml
+        working-directory: ./sample-xml
+        run: ./gradlew koverMergedHtmlReport
+
+      - name: Archive code coverage reports on sample-xml
+        uses: actions/upload-artifact@v2
+        with:
+          name: CodeCoverageReportsTemplateXML
+          path: sample-xml/build/reports/kover/merged/
+
+      # sample-compose
+
+      - name: Run Detekt on sample-compose
+        working-directory: ./sample-compose
+        run: ./gradlew detekt
+
+      - name: Archive Detekt reports on sample-compose
+        uses: actions/upload-artifact@v2
+        with:
+          name: DetektReportsTemplateCompose
+          path: sample-compose/build/reports/detekt/
+
+      - name: Run unit tests with Kover on sample-compose
+        working-directory: ./sample-compose
+        run: ./gradlew koverMergedHtmlReport
+
+      - name: Archive code coverage reports on sample-compose
+        uses: actions/upload-artifact@v2
+        with:
+          name: CodeCoverageReportsTemplateCompose
+          path: sample-compose/build/reports/kover/merged/

--- a/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.rule.GrantPermissionRule
 import co.nimblehq.sample.compose.domain.model.Model
-import co.nimblehq.sample.compose.domain.usecase.UseCase
+import co.nimblehq.sample.compose.domain.usecase.*
 import co.nimblehq.sample.compose.test.TestDispatchersProvider
 import co.nimblehq.sample.compose.ui.AppDestination
 import co.nimblehq.sample.compose.ui.screens.MainActivity
@@ -31,19 +31,24 @@ class HomeScreenTest {
         android.Manifest.permission.CAMERA
     )
 
-    private val mockUseCase: UseCase = mockk()
+    private val mockGetModelsUseCase: GetModelsUseCase = mockk()
+    private val mockIsFirstTimeLaunchPreferencesUseCase: IsFirstTimeLaunchPreferencesUseCase = mockk()
+    private val mockUpdateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase = mockk()
 
     private lateinit var viewModel: HomeViewModel
     private var expectedAppDestination: AppDestination? = null
 
     @Before
     fun setUp() {
-        every { mockUseCase() } returns flowOf(
+        every { mockGetModelsUseCase() } returns flowOf(
             listOf(Model(1), Model(2), Model(3))
         )
+        every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(false)
 
         viewModel = HomeViewModel(
-            mockUseCase,
+            mockGetModelsUseCase,
+            mockIsFirstTimeLaunchPreferencesUseCase,
+            mockUpdateFirstTimeLaunchPreferencesUseCase,
             TestDispatchersProvider
         )
     }

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -8,7 +8,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.rule.GrantPermissionRule
 import co.nimblehq.sample.compose.R
 import co.nimblehq.sample.compose.domain.model.Model
-import co.nimblehq.sample.compose.domain.usecase.UseCase
+import co.nimblehq.sample.compose.domain.usecase.*
 import co.nimblehq.sample.compose.test.CoroutineTestRule
 import co.nimblehq.sample.compose.ui.AppDestination
 import co.nimblehq.sample.compose.ui.screens.MainActivity
@@ -41,16 +41,19 @@ class HomeScreenTest {
         android.Manifest.permission.CAMERA
     )
 
-    private val mockUseCase: UseCase = mockk()
+    private val mockGetModelsUseCase: GetModelsUseCase = mockk()
+    private val mockIsFirstTimeLaunchPreferencesUseCase: IsFirstTimeLaunchPreferencesUseCase = mockk()
+    private val mockUpdateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase = mockk()
 
     private lateinit var viewModel: HomeViewModel
     private var expectedAppDestination: AppDestination? = null
 
     @Before
     fun setUp() {
-        every { mockUseCase() } returns flowOf(
+        every { mockGetModelsUseCase() } returns flowOf(
             listOf(Model(1), Model(2), Model(3))
         )
+        every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(false)
 
         initViewModel()
     }
@@ -68,7 +71,7 @@ class HomeScreenTest {
     @Test
     fun `When entering the Home screen and loading the list item failure, it shows the corresponding error`() {
         val error = Exception()
-        every { mockUseCase() } returns flow { throw error }
+        every { mockGetModelsUseCase() } returns flow { throw error }
         initViewModel()
 
         initComposable {
@@ -101,7 +104,9 @@ class HomeScreenTest {
 
     private fun initViewModel() {
         viewModel = HomeViewModel(
-            mockUseCase,
+            mockGetModelsUseCase,
+            mockIsFirstTimeLaunchPreferencesUseCase,
+            mockUpdateFirstTimeLaunchPreferencesUseCase,
             coroutinesRule.testDispatcherProvider
         )
     }

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
@@ -2,7 +2,7 @@ package co.nimblehq.sample.compose.ui.screens.home
 
 import app.cash.turbine.test
 import co.nimblehq.sample.compose.domain.model.Model
-import co.nimblehq.sample.compose.domain.usecase.UseCase
+import co.nimblehq.sample.compose.domain.usecase.*
 import co.nimblehq.sample.compose.model.toUiModel
 import co.nimblehq.sample.compose.test.CoroutineTestRule
 import co.nimblehq.sample.compose.ui.AppDestination
@@ -22,7 +22,9 @@ class HomeViewModelTest {
     @get:Rule
     val coroutinesRule = CoroutineTestRule()
 
-    private val mockUseCase: UseCase = mockk()
+    private val mockGetModelsUseCase: GetModelsUseCase = mockk()
+    private val mockIsFirstTimeLaunchPreferencesUseCase: IsFirstTimeLaunchPreferencesUseCase = mockk()
+    private val mockUpdateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase = mockk()
 
     private lateinit var viewModel: HomeViewModel
 
@@ -30,7 +32,8 @@ class HomeViewModelTest {
 
     @Before
     fun setUp() {
-        every { mockUseCase() } returns flowOf(models)
+        every { mockGetModelsUseCase() } returns flowOf(models)
+        every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(false)
 
         initViewModel()
     }
@@ -45,7 +48,7 @@ class HomeViewModelTest {
     @Test
     fun `When loading models failed, it shows the corresponding error`() = runTest {
         val error = Exception()
-        every { mockUseCase() } returns flow { throw error }
+        every { mockGetModelsUseCase() } returns flow { throw error }
         initViewModel(dispatchers = CoroutineTestRule(StandardTestDispatcher()).testDispatcherProvider)
 
         viewModel.error.test {
@@ -59,7 +62,7 @@ class HomeViewModelTest {
     fun `When loading models, it shows and hides loading correctly`() = runTest {
         initViewModel(dispatchers = CoroutineTestRule(StandardTestDispatcher()).testDispatcherProvider)
 
-        viewModel.showLoading.test {
+        viewModel.isLoading.test {
             awaitItem() shouldBe false
             awaitItem() shouldBe true
             awaitItem() shouldBe false
@@ -77,7 +80,9 @@ class HomeViewModelTest {
 
     private fun initViewModel(dispatchers: DispatchersProvider = coroutinesRule.testDispatcherProvider) {
         viewModel = HomeViewModel(
-            mockUseCase,
+            mockGetModelsUseCase,
+            mockIsFirstTimeLaunchPreferencesUseCase,
+            mockUpdateFirstTimeLaunchPreferencesUseCase,
             dispatchers
         )
     }


### PR DESCRIPTION
Resolves https://github.com/nimblehq/android-templates/issues/443

## What happened 👀

- Add more steps to verify the `sample-xml` & `sample-compose` projects.
- Fix: missing UseCases setup & mocking in tests.

## Insight 📝

The number of steps in this workflow [run_detekt_and_unit_tests.yml](https://github.com/nimblehq/android-templates/blob/develop/.github/workflows/run_detekt_and_unit_tests.yml) is increased for 4 projects, we need to have some delimiters for better grouping.

## Proof Of Work 📹

The workflow [run_detekt_and_unit_tests.yml](https://github.com/nimblehq/android-templates/blob/develop/.github/workflows/run_detekt_and_unit_tests.yml) is passed ✅ 
