### PR TITLE
Trying ChatGPT Code Review

### DIFF
--- a/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -46,10 +46,10 @@ class HomeScreenTest {
         every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(false)
 
         viewModel = HomeViewModel(
+            TestDispatchersProvider,
             mockGetModelsUseCase,
             mockIsFirstTimeLaunchPreferencesUseCase,
-            mockUpdateFirstTimeLaunchPreferencesUseCase,
-            TestDispatchersProvider
+            mockUpdateFirstTimeLaunchPreferencesUseCase
         )
     }
 

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/base/BaseViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/base/BaseViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.nimblehq.sample.compose.lib.IsLoading
 import co.nimblehq.sample.compose.ui.AppDestination
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 @Suppress("PropertyName")
 abstract class BaseViewModel : ViewModel() {
@@ -41,8 +43,8 @@ abstract class BaseViewModel : ViewModel() {
         }
     }
 
-    protected fun launch(job: suspend () -> Unit) =
-        viewModelScope.launch {
+    protected fun launch(context: CoroutineContext = EmptyCoroutineContext, job: suspend () -> Unit) =
+        viewModelScope.launch(context) {
             job.invoke()
         }
 

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/base/BaseViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/base/BaseViewModel.kt
@@ -4,27 +4,22 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.nimblehq.sample.compose.lib.IsLoading
 import co.nimblehq.sample.compose.ui.AppDestination
-import co.nimblehq.sample.compose.util.DispatchersProvider
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 @Suppress("PropertyName")
-abstract class BaseViewModel(private val dispatchersProvider: DispatchersProvider) : ViewModel() {
+abstract class BaseViewModel : ViewModel() {
 
     private var loadingCount: Int = 0
 
     private val _isLoading = MutableStateFlow(false)
-    val isLoading: StateFlow<IsLoading>
-        get() = _isLoading
+    val isLoading: StateFlow<IsLoading> = _isLoading
 
     protected val _error = MutableStateFlow<Throwable?>(null)
-    val error: StateFlow<Throwable?>
-        get() = _error
+    val error: StateFlow<Throwable?> = _error
 
     protected val _navigator = MutableSharedFlow<AppDestination>()
-    val navigator: SharedFlow<AppDestination>
-        get() = _navigator
+    val navigator: SharedFlow<AppDestination> = _navigator
 
     /**
      * To show loading manually, should call `hideLoading` after
@@ -46,8 +41,12 @@ abstract class BaseViewModel(private val dispatchersProvider: DispatchersProvide
         }
     }
 
-    fun execute(coroutineDispatcher: CoroutineDispatcher = dispatchersProvider.io, job: suspend () -> Unit) =
-        viewModelScope.launch(coroutineDispatcher) {
+    protected fun launch(job: suspend () -> Unit) =
+        viewModelScope.launch {
             job.invoke()
         }
+
+    protected fun <T> Flow<T>.injectLoading(): Flow<T> = this
+        .onStart { showLoading() }
+        .onCompletion { hideLoading() }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
@@ -1,11 +1,11 @@
 package co.nimblehq.sample.compose.ui.screens.home
 
+import androidx.lifecycle.viewModelScope
 import co.nimblehq.sample.compose.domain.usecase.*
 import co.nimblehq.sample.compose.model.UiModel
 import co.nimblehq.sample.compose.model.toUiModel
 import co.nimblehq.sample.compose.ui.AppDestination
 import co.nimblehq.sample.compose.ui.base.BaseViewModel
-import co.nimblehq.sample.compose.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
@@ -19,32 +19,25 @@ class HomeViewModel @Inject constructor(
 ) : BaseViewModel(dispatchers) {
 
     private val _uiModels = MutableStateFlow<List<UiModel>>(emptyList())
-    val uiModels: StateFlow<List<UiModel>>
-        get() = _uiModels
+    val uiModels: StateFlow<List<UiModel>> = _uiModels
 
     private val _isFirstTimeLaunch = MutableStateFlow(false)
-    val isFirstTimeLaunch: StateFlow<Boolean>
-        get() = _isFirstTimeLaunch
+    val isFirstTimeLaunch: StateFlow<Boolean> = _isFirstTimeLaunch
 
     init {
-        execute {
-            showLoading()
-            getModelsUseCase()
-                .catch {
-                    _error.emit(it)
-                }
-                .collect { result ->
-                    val uiModels = result.map { it.toUiModel() }
-                    _uiModels.emit(uiModels)
-                }
-            hideLoading()
-        }
+        getModelsUseCase()
+            .injectLoading()
+            .onEach { result ->
+                val uiModels = result.map { it.toUiModel() }
+                _uiModels.emit(uiModels)
+            }
+            .catch { e -> _error.emit(e) }
+            .launchIn(viewModelScope)
 
-        execute {
+        launch {
             val isFirstTimeLaunch = isFirstTimeLaunchPreferencesUseCase()
-                .catch {
-                    _error.emit(it)
-                }.first()
+                .catch { e -> _error.emit(e) }
+                .first()
 
             _isFirstTimeLaunch.emit(isFirstTimeLaunch)
             if (isFirstTimeLaunch) {
@@ -54,10 +47,10 @@ class HomeViewModel @Inject constructor(
     }
 
     fun navigateToSecond(uiModel: UiModel) {
-        execute { _navigator.emit(AppDestination.Second.createRoute(uiModel.id)) }
+        launch { _navigator.emit(AppDestination.Second.createRoute(uiModel.id)) }
     }
 
     fun navigateToThird(uiModel: UiModel) {
-        execute { _navigator.emit(AppDestination.Third.addParcel(uiModel)) }
+        launch { _navigator.emit(AppDestination.Third.addParcel(uiModel)) }
     }
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
@@ -6,17 +6,18 @@ import co.nimblehq.sample.compose.model.UiModel
 import co.nimblehq.sample.compose.model.toUiModel
 import co.nimblehq.sample.compose.ui.AppDestination
 import co.nimblehq.sample.compose.ui.base.BaseViewModel
+import co.nimblehq.sample.compose.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val getModelsUseCase: GetModelsUseCase,
+    dispatchers: DispatchersProvider,
+    getModelsUseCase: GetModelsUseCase,
     private val isFirstTimeLaunchPreferencesUseCase: IsFirstTimeLaunchPreferencesUseCase,
-    private val updateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase,
-    dispatchers: DispatchersProvider
-) : BaseViewModel(dispatchers) {
+    private val updateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase
+) : BaseViewModel() {
 
     private val _uiModels = MutableStateFlow<List<UiModel>>(emptyList())
     val uiModels: StateFlow<List<UiModel>> = _uiModels
@@ -31,10 +32,11 @@ class HomeViewModel @Inject constructor(
                 val uiModels = result.map { it.toUiModel() }
                 _uiModels.emit(uiModels)
             }
+            .flowOn(dispatchers.io)
             .catch { e -> _error.emit(e) }
             .launchIn(viewModelScope)
 
-        launch {
+        launch(dispatchers.io) {
             val isFirstTimeLaunch = isFirstTimeLaunchPreferencesUseCase()
                 .catch { e -> _error.emit(e) }
                 .first()

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/second/SecondViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/second/SecondViewModel.kt
@@ -1,11 +1,8 @@
 package co.nimblehq.sample.compose.ui.screens.second
 
 import co.nimblehq.sample.compose.ui.base.BaseViewModel
-import co.nimblehq.sample.compose.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class SecondViewModel @Inject constructor(
-    dispatchers: DispatchersProvider
-) : BaseViewModel(dispatchers)
+class SecondViewModel @Inject constructor() : BaseViewModel()

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/third/ThirdViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/third/ThirdViewModel.kt
@@ -1,13 +1,8 @@
 package co.nimblehq.sample.compose.ui.screens.third
 
-import androidx.lifecycle.SavedStateHandle
 import co.nimblehq.sample.compose.ui.base.BaseViewModel
-import co.nimblehq.sample.compose.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class ThirdViewModel @Inject constructor(
-    dispatchers: DispatchersProvider,
-    savedStateHandle: SavedStateHandle
-) : BaseViewModel(dispatchers) {}
+class ThirdViewModel @Inject constructor() : BaseViewModel()

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -104,10 +104,10 @@ class HomeScreenTest {
 
     private fun initViewModel() {
         viewModel = HomeViewModel(
+            coroutinesRule.testDispatcherProvider,
             mockGetModelsUseCase,
             mockIsFirstTimeLaunchPreferencesUseCase,
-            mockUpdateFirstTimeLaunchPreferencesUseCase,
-            coroutinesRule.testDispatcherProvider
+            mockUpdateFirstTimeLaunchPreferencesUseCase
         )
     }
 }

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
@@ -80,10 +80,10 @@ class HomeViewModelTest {
 
     private fun initViewModel(dispatchers: DispatchersProvider = coroutinesRule.testDispatcherProvider) {
         viewModel = HomeViewModel(
+            dispatchers,
             mockGetModelsUseCase,
             mockIsFirstTimeLaunchPreferencesUseCase,
-            mockUpdateFirstTimeLaunchPreferencesUseCase,
-            dispatchers
+            mockUpdateFirstTimeLaunchPreferencesUseCase
         )
     }
 }

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/model/UiModel.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/model/UiModel.kt
@@ -9,6 +9,4 @@ data class UiModel(
     val id: String
 ) : Parcelable
 
-private fun Model.toUiModel() = UiModel(id = id.toString())
-
-fun List<Model>.toUiModels() = this.map { it.toUiModel() }
+fun Model.toUiModel() = UiModel(id = id.toString())

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/base/BaseViewModel.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/base/BaseViewModel.kt
@@ -3,27 +3,22 @@ package co.nimblehq.sample.xml.ui.base
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.nimblehq.sample.xml.lib.IsLoading
-import co.nimblehq.sample.xml.util.DispatchersProvider
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 @Suppress("PropertyName")
-abstract class BaseViewModel(private val dispatchersProvider: DispatchersProvider) : ViewModel() {
+abstract class BaseViewModel : ViewModel() {
 
     private var loadingCount: Int = 0
 
     private val _isLoading = MutableStateFlow(false)
-    val isLoading: StateFlow<IsLoading>
-        get() = _isLoading
+    val isLoading: StateFlow<IsLoading> = _isLoading
 
     protected val _error = MutableSharedFlow<Throwable>()
-    val error: SharedFlow<Throwable>
-        get() = _error
+    val error: SharedFlow<Throwable> = _error
 
     protected val _navigator = MutableSharedFlow<NavigationEvent>()
-    val navigator: SharedFlow<NavigationEvent>
-        get() = _navigator
+    val navigator: SharedFlow<NavigationEvent> = _navigator
 
     /**
      * To show loading manually, should call `hideLoading` after
@@ -45,8 +40,12 @@ abstract class BaseViewModel(private val dispatchersProvider: DispatchersProvide
         }
     }
 
-    fun execute(coroutineDispatcher: CoroutineDispatcher = dispatchersProvider.io, job: suspend () -> Unit) =
-        viewModelScope.launch(coroutineDispatcher) {
+    protected fun launch(job: suspend () -> Unit) =
+        viewModelScope.launch {
             job.invoke()
         }
+
+    protected fun <T> Flow<T>.injectLoading(): Flow<T> = this
+        .onStart { showLoading() }
+        .onCompletion { hideLoading() }
 }

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/base/BaseViewModel.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/base/BaseViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import co.nimblehq.sample.xml.lib.IsLoading
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 @Suppress("PropertyName")
 abstract class BaseViewModel : ViewModel() {
@@ -40,8 +42,8 @@ abstract class BaseViewModel : ViewModel() {
         }
     }
 
-    protected fun launch(job: suspend () -> Unit) =
-        viewModelScope.launch {
+    protected fun launch(context: CoroutineContext = EmptyCoroutineContext, job: suspend () -> Unit) =
+        viewModelScope.launch(context) {
             job.invoke()
         }
 

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/MainViewModel.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/MainViewModel.kt
@@ -1,11 +1,8 @@
 package co.nimblehq.sample.xml.ui.screens
 
 import co.nimblehq.sample.xml.ui.base.BaseViewModel
-import co.nimblehq.sample.xml.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class MainViewModel @Inject constructor(
-    dispatchers: DispatchersProvider
-) : BaseViewModel(dispatchers)
+class MainViewModel @Inject constructor() : BaseViewModel()

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/home/HomeViewModel.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/home/HomeViewModel.kt
@@ -1,50 +1,42 @@
 package co.nimblehq.sample.xml.ui.screens.home
 
+import androidx.lifecycle.viewModelScope
 import co.nimblehq.sample.xml.domain.usecase.*
 import co.nimblehq.sample.xml.model.UiModel
-import co.nimblehq.sample.xml.model.toUiModels
+import co.nimblehq.sample.xml.model.toUiModel
 import co.nimblehq.sample.xml.ui.base.BaseViewModel
 import co.nimblehq.sample.xml.ui.base.NavigationEvent
-import co.nimblehq.sample.xml.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val getModelsUseCase: GetModelsUseCase,
+    getModelsUseCase: GetModelsUseCase,
     private val isFirstTimeLaunchPreferencesUseCase: IsFirstTimeLaunchPreferencesUseCase,
-    private val updateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase,
-    dispatchers: DispatchersProvider
-) : BaseViewModel(dispatchers) {
+    private val updateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase
+) : BaseViewModel() {
 
     private val _uiModels = MutableStateFlow<List<UiModel>>(emptyList())
-    val uiModels: StateFlow<List<UiModel>>
-        get() = _uiModels
+    val uiModels: StateFlow<List<UiModel>> = _uiModels
 
     private val _isFirstTimeLaunch = MutableSharedFlow<Boolean>()
-    val isFirstTimeLaunch: SharedFlow<Boolean>
-        get() = _isFirstTimeLaunch
+    val isFirstTimeLaunch: SharedFlow<Boolean> = _isFirstTimeLaunch
 
     init {
-        execute {
-            showLoading()
-            getModelsUseCase()
-                .catch {
-                    _error.emit(it)
-                }
-                .collect { result ->
-                    val uiModels = result.toUiModels()
-                    _uiModels.emit(uiModels)
-                }
-            hideLoading()
-        }
+        getModelsUseCase()
+            .injectLoading()
+            .onEach { result ->
+                val uiModels = result.map { it.toUiModel() }
+                _uiModels.emit(uiModels)
+            }
+            .catch { e -> _error.emit(e) }
+            .launchIn(viewModelScope)
 
-        execute {
+        launch {
             val isFirstTimeLaunch = isFirstTimeLaunchPreferencesUseCase()
-                .catch {
-                    _error.emit(it)
-                }.first()
+                .catch { e -> _error.emit(e) }
+                .first()
 
             _isFirstTimeLaunch.emit(isFirstTimeLaunch)
             if (isFirstTimeLaunch) {
@@ -54,6 +46,6 @@ class HomeViewModel @Inject constructor(
     }
 
     fun navigateToSecond(uiModel: UiModel) {
-        execute { _navigator.emit(NavigationEvent.Second(uiModel)) }
+        launch { _navigator.emit(NavigationEvent.Second(uiModel)) }
     }
 }

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/home/HomeViewModel.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/home/HomeViewModel.kt
@@ -6,12 +6,14 @@ import co.nimblehq.sample.xml.model.UiModel
 import co.nimblehq.sample.xml.model.toUiModel
 import co.nimblehq.sample.xml.ui.base.BaseViewModel
 import co.nimblehq.sample.xml.ui.base.NavigationEvent
+import co.nimblehq.sample.xml.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
+    dispatchers: DispatchersProvider,
     getModelsUseCase: GetModelsUseCase,
     private val isFirstTimeLaunchPreferencesUseCase: IsFirstTimeLaunchPreferencesUseCase,
     private val updateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase
@@ -30,10 +32,11 @@ class HomeViewModel @Inject constructor(
                 val uiModels = result.map { it.toUiModel() }
                 _uiModels.emit(uiModels)
             }
+            .flowOn(dispatchers.io)
             .catch { e -> _error.emit(e) }
             .launchIn(viewModelScope)
 
-        launch {
+        launch(dispatchers.io) {
             val isFirstTimeLaunch = isFirstTimeLaunchPreferencesUseCase()
                 .catch { e -> _error.emit(e) }
                 .first()

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/second/SecondViewModel.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/second/SecondViewModel.kt
@@ -2,20 +2,17 @@ package co.nimblehq.sample.xml.ui.screens.second
 
 import co.nimblehq.sample.xml.model.UiModel
 import co.nimblehq.sample.xml.ui.base.BaseViewModel
-import co.nimblehq.sample.xml.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class SecondViewModel @Inject constructor(
-    dispatchers: DispatchersProvider
-) : BaseViewModel(dispatchers) {
+class SecondViewModel @Inject constructor() : BaseViewModel() {
 
     private val _id = MutableStateFlow<String?>(null)
     val id: StateFlow<String?>
         get() = _id
 
-    fun initViewModel(uiModel: UiModel) = execute { _id.emit(uiModel.id) }
+    fun initViewModel(uiModel: UiModel) = launch { _id.emit(uiModel.id) }
 }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/base/BaseViewModel.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/base/BaseViewModel.kt
@@ -6,6 +6,8 @@ import co.nimblehq.template.compose.lib.IsLoading
 import co.nimblehq.template.compose.ui.AppDestination
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 @Suppress("PropertyName")
 abstract class BaseViewModel : ViewModel() {
@@ -41,8 +43,8 @@ abstract class BaseViewModel : ViewModel() {
         }
     }
 
-    protected fun launch(job: suspend () -> Unit) =
-        viewModelScope.launch {
+    protected fun launch(context: CoroutineContext = EmptyCoroutineContext, job: suspend () -> Unit) =
+        viewModelScope.launch(context) {
             job.invoke()
         }
 

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModel.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModel.kt
@@ -5,12 +5,14 @@ import co.nimblehq.template.compose.domain.usecase.UseCase
 import co.nimblehq.template.compose.model.UiModel
 import co.nimblehq.template.compose.model.toUiModel
 import co.nimblehq.template.compose.ui.base.BaseViewModel
+import co.nimblehq.template.compose.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
+    dispatchers: DispatchersProvider,
     useCase: UseCase
 ) : BaseViewModel() {
 
@@ -24,6 +26,7 @@ class HomeViewModel @Inject constructor(
                 val uiModels = result.map { it.toUiModel() }
                 _uiModels.emit(uiModels)
             }
+            .flowOn(dispatchers.io)
             .catch { e -> _error.emit(e) }
             .launchIn(viewModelScope)
     }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModel.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModel.kt
@@ -1,36 +1,30 @@
 package co.nimblehq.template.compose.ui.screens.home
 
+import androidx.lifecycle.viewModelScope
 import co.nimblehq.template.compose.domain.usecase.UseCase
 import co.nimblehq.template.compose.model.UiModel
 import co.nimblehq.template.compose.model.toUiModel
 import co.nimblehq.template.compose.ui.base.BaseViewModel
-import co.nimblehq.template.compose.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val useCase: UseCase,
-    dispatchers: DispatchersProvider
-) : BaseViewModel(dispatchers) {
+    useCase: UseCase
+) : BaseViewModel() {
 
     private val _uiModels = MutableStateFlow<List<UiModel>>(emptyList())
-    val uiModels: StateFlow<List<UiModel>>
-        get() = _uiModels
+    val uiModels: StateFlow<List<UiModel>> = _uiModels
 
     init {
-        execute {
-            showLoading()
-            useCase()
-                .catch {
-                    _error.emit(it)
-                }
-                .collect { result ->
-                    val uiModels = result.map { it.toUiModel() }
-                    _uiModels.emit(uiModels)
-                }
-            hideLoading()
-        }
+        useCase()
+            .injectLoading()
+            .onEach { result ->
+                val uiModels = result.map { it.toUiModel() }
+                _uiModels.emit(uiModels)
+            }
+            .catch { e -> _error.emit(e) }
+            .launchIn(viewModelScope)
     }
 }

--- a/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModelTest.kt
+++ b/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModelTest.kt
@@ -67,8 +67,8 @@ class HomeViewModelTest {
 
     private fun initViewModel(dispatchers: DispatchersProvider = coroutinesRule.testDispatcherProvider) {
         viewModel = HomeViewModel(
-            mockUseCase,
-            dispatchers
+            dispatchers,
+            mockUseCase
         )
     }
 }

--- a/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModelTest.kt
+++ b/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModelTest.kt
@@ -58,7 +58,7 @@ class HomeViewModelTest {
     fun `When loading models, it shows and hides loading correctly`() = runTest {
         initViewModel(dispatchers = CoroutineTestRule(StandardTestDispatcher()).testDispatcherProvider)
 
-        viewModel.showLoading.test {
+        viewModel.isLoading.test {
             awaitItem() shouldBe false
             awaitItem() shouldBe true
             awaitItem() shouldBe false

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/model/UiModel.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/model/UiModel.kt
@@ -6,6 +6,4 @@ data class UiModel(
     val id: Int
 )
 
-private fun Model.toUiModel() = UiModel(id = id ?: -1)
-
-fun List<Model>.toUiModels() = this.map { it.toUiModel() }
+fun Model.toUiModel() = UiModel(id = id ?: -1)

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/ui/base/BaseViewModel.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/ui/base/BaseViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import co.nimblehq.template.xml.lib.IsLoading
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 @Suppress("PropertyName")
 abstract class BaseViewModel : ViewModel() {
@@ -40,8 +42,8 @@ abstract class BaseViewModel : ViewModel() {
         }
     }
 
-    protected fun launch(job: suspend () -> Unit) =
-        viewModelScope.launch {
+    protected fun launch(context: CoroutineContext = EmptyCoroutineContext, job: suspend () -> Unit) =
+        viewModelScope.launch(context) {
             job.invoke()
         }
 

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/ui/base/BaseViewModel.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/ui/base/BaseViewModel.kt
@@ -3,34 +3,29 @@ package co.nimblehq.template.xml.ui.base
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.nimblehq.template.xml.lib.IsLoading
-import co.nimblehq.template.xml.util.DispatchersProvider
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 @Suppress("PropertyName")
-abstract class BaseViewModel(private val dispatchersProvider: DispatchersProvider) : ViewModel() {
+abstract class BaseViewModel : ViewModel() {
 
     private var loadingCount: Int = 0
 
-    private val _showLoading = MutableStateFlow(false)
-    val showLoading: StateFlow<IsLoading>
-        get() = _showLoading
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<IsLoading> = _isLoading
 
     protected val _error = MutableSharedFlow<Throwable>()
-    val error: SharedFlow<Throwable>
-        get() = _error
+    val error: SharedFlow<Throwable> = _error
 
     protected val _navigator = MutableSharedFlow<NavigationEvent>()
-    val navigator: SharedFlow<NavigationEvent>
-        get() = _navigator
+    val navigator: SharedFlow<NavigationEvent> = _navigator
 
     /**
      * To show loading manually, should call `hideLoading` after
      */
     protected fun showLoading() {
         if (loadingCount == 0) {
-            _showLoading.value = true
+            _isLoading.value = true
         }
         loadingCount++
     }
@@ -41,12 +36,16 @@ abstract class BaseViewModel(private val dispatchersProvider: DispatchersProvide
     protected fun hideLoading() {
         loadingCount--
         if (loadingCount == 0) {
-            _showLoading.value = false
+            _isLoading.value = false
         }
     }
 
-    fun execute(coroutineDispatcher: CoroutineDispatcher = dispatchersProvider.io, job: suspend () -> Unit) =
-        viewModelScope.launch(coroutineDispatcher) {
+    protected fun launch(job: suspend () -> Unit) =
+        viewModelScope.launch {
             job.invoke()
         }
+
+    protected fun <T> Flow<T>.injectLoading(): Flow<T> = this
+        .onStart { showLoading() }
+        .onCompletion { hideLoading() }
 }

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/ui/screens/MainViewModel.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/ui/screens/MainViewModel.kt
@@ -1,11 +1,8 @@
 package co.nimblehq.template.xml.ui.screens
 
 import co.nimblehq.template.xml.ui.base.BaseViewModel
-import co.nimblehq.template.xml.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class MainViewModel @Inject constructor(
-    dispatchers: DispatchersProvider
-) : BaseViewModel(dispatchers)
+class MainViewModel @Inject constructor() : BaseViewModel()

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/ui/screens/home/HomeViewModel.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/ui/screens/home/HomeViewModel.kt
@@ -5,12 +5,14 @@ import co.nimblehq.template.xml.domain.usecase.UseCase
 import co.nimblehq.template.xml.model.UiModel
 import co.nimblehq.template.xml.model.toUiModel
 import co.nimblehq.template.xml.ui.base.BaseViewModel
+import co.nimblehq.template.xml.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
+    dispatchers: DispatchersProvider,
     useCase: UseCase
 ) : BaseViewModel() {
 
@@ -24,6 +26,7 @@ class HomeViewModel @Inject constructor(
                 val uiModels = result.map { it.toUiModel() }
                 _uiModels.emit(uiModels)
             }
+            .flowOn(dispatchers.io)
             .catch { e -> _error.emit(e) }
             .launchIn(viewModelScope)
     }

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/ui/screens/home/HomeViewModel.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/ui/screens/home/HomeViewModel.kt
@@ -1,36 +1,30 @@
 package co.nimblehq.template.xml.ui.screens.home
 
+import androidx.lifecycle.viewModelScope
 import co.nimblehq.template.xml.domain.usecase.UseCase
 import co.nimblehq.template.xml.model.UiModel
-import co.nimblehq.template.xml.model.toUiModels
+import co.nimblehq.template.xml.model.toUiModel
 import co.nimblehq.template.xml.ui.base.BaseViewModel
-import co.nimblehq.template.xml.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val useCase: UseCase,
-    dispatchers: DispatchersProvider
-) : BaseViewModel(dispatchers) {
+    useCase: UseCase
+) : BaseViewModel() {
 
     private val _uiModels = MutableStateFlow<List<UiModel>>(emptyList())
-    val uiModels: StateFlow<List<UiModel>>
-        get() = _uiModels
+    val uiModels: StateFlow<List<UiModel>> = _uiModels
 
     init {
-        execute {
-            showLoading()
-            useCase()
-                .catch {
-                    _error.emit(it)
-                }
-                .collect { result ->
-                    val uiModels = result.toUiModels()
-                    _uiModels.emit(uiModels)
-                }
-            hideLoading()
-        }
+        useCase()
+            .injectLoading()
+            .onEach { result ->
+                val uiModels = result.map { it.toUiModel() }
+                _uiModels.emit(uiModels)
+            }
+            .catch { e -> _error.emit(e) }
+            .launchIn(viewModelScope)
     }
 }


### PR DESCRIPTION
Closes https://github.com/nimblehq/android-templates/issues/425

## What happened 👀

- Use `launchIn` instead of `collect` for collecting Flows in ViewModel.
- Replace the old `execute` protected fun in BaseViewModel with the new `launch` fun (renaming for consistency).
- Add `injectLoading` fun to reduce the logic for `showLoading` and `hideLoading` at `onStart` and `onCompletion` in each Flow.

## Insight 📝

- The new `launch` fun should accept `EmptyCoroutineContext` as default ([same as the original fun](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/launch.html)). [With `EmptyCoroutineContext`, the `Dispatchers.Default` is used](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/launch.html) 👉 **main thread**, to launch the Job.

  <img width="1117" alt="image" src="https://user-images.githubusercontent.com/16315358/226787795-ad620e90-63ec-4d33-80be-87a4ed4bf081.png">

- [To launch a Flow in a specific CoroutineContext](https://developer.android.com/kotlin/flow), such as `IO` for storage or network execution. We must use [`flowOn`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/flow-on.html), e.g. `.flowOn(dispatchers.io)`. Hence, we don't need to pass `DispatchersProvider` into the BaseViewModel.
- Note that `flowOn` changes the CoroutineContext of the upstream flow.

  ![image](https://user-images.githubusercontent.com/16315358/226789924-ee6030ad-0d71-4dc9-aab9-1dc32c7b60c5.png)

- This update ensures we will not launch all unnecessary Flows on Dispatcher.IO at all times.

  Before ❌  https://github.com/nimblehq/android-templates/blob/5a037e8ca67447e70610463bb77f2146a56a6e66/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/base/BaseViewModel.kt#L49-L52
  
  After ✅  https://github.com/nimblehq/android-templates/blob/869f82ea73f98e9a47d5934485ff0a3810a5cb7a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt#L29-L37

- `.catch { }` should always be put at the end of a Flow collector, in front of `.launchIn` to catch all the prior errors.

## Proof Of Work 📹

- All the core app logic remains the same as before ✅ 
- All tests are passed ✅ 
