### PR TITLE
Try ChatGPT Code Review on #228

### DIFF
--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/di/Authenticate.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/di/Authenticate.kt
@@ -1,0 +1,7 @@
+package co.nimblehq.template.xml.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class Authenticate

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/di/modules/AuthModule.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/di/modules/AuthModule.kt
@@ -1,0 +1,22 @@
+package co.nimblehq.template.xml.di.modules
+
+import co.nimblehq.template.xml.data.repository.SessionManagerImpl
+import co.nimblehq.template.xml.data.repository.TokenRefresherImpl
+import co.nimblehq.template.xml.data.service.AuthService
+import co.nimblehq.template.xml.data.service.SessionManager
+import co.nimblehq.template.xml.data.service.authenticator.TokenRefresher
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+class AuthModule {
+
+    @Provides
+    fun provideAuthService(authService: AuthService): TokenRefresher = TokenRefresherImpl(authService)
+
+    @Provides
+    fun provideSessionManager(): SessionManager = SessionManagerImpl()
+}

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/di/modules/OkHttpClientModule.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/di/modules/OkHttpClientModule.kt
@@ -2,6 +2,10 @@ package co.nimblehq.template.xml.di.modules
 
 import android.content.Context
 import co.nimblehq.template.xml.BuildConfig
+import co.nimblehq.template.xml.data.service.SessionManager
+import co.nimblehq.template.xml.data.service.authenticator.ApplicationRequestAuthenticator
+import co.nimblehq.template.xml.data.service.authenticator.TokenRefresher
+import co.nimblehq.template.xml.di.Authenticate
 import com.chuckerteam.chucker.api.*
 import dagger.Module
 import dagger.Provides
@@ -20,16 +24,42 @@ class OkHttpClientModule {
 
     @Provides
     fun provideOkHttpClient(
-        chuckerInterceptor: ChuckerInterceptor
-    ) = OkHttpClient.Builder().apply {
-        if (BuildConfig.DEBUG) {
-            addInterceptor(HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BODY
-            })
-            addInterceptor(chuckerInterceptor)
-            readTimeout(READ_TIME_OUT, TimeUnit.SECONDS)
-        }
-    }.build()
+        chuckerInterceptor: ChuckerInterceptor,
+        sessionManager: SessionManager,
+        tokenRefresher: TokenRefresher?
+    ): OkHttpClient {
+        val authenticator =
+            tokenRefresher?.let { ApplicationRequestAuthenticator(it, sessionManager) }
+        return OkHttpClient.Builder()
+            .apply {
+                if (BuildConfig.DEBUG) {
+                    addInterceptor(HttpLoggingInterceptor().apply {
+                        level = HttpLoggingInterceptor.Level.BODY
+                    })
+                    addInterceptor(chuckerInterceptor)
+                    readTimeout(READ_TIME_OUT, TimeUnit.SECONDS)
+                }
+            }
+            .build()
+            .apply { authenticator?.okHttpClient = this }
+
+    }
+
+    @Authenticate
+    @Provides
+    fun provideAuthOkHttpClient(chuckerInterceptor: ChuckerInterceptor): OkHttpClient {
+        return OkHttpClient.Builder()
+            .apply {
+                if (BuildConfig.DEBUG) {
+                    addInterceptor(HttpLoggingInterceptor().apply {
+                        level = HttpLoggingInterceptor.Level.BODY
+                    })
+                    addInterceptor(chuckerInterceptor)
+                    readTimeout(READ_TIME_OUT, TimeUnit.SECONDS)
+                }
+            }
+            .build()
+    }
 
     @Provides
     fun provideChuckerInterceptor(

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/di/modules/RetrofitModule.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/di/modules/RetrofitModule.kt
@@ -2,9 +2,11 @@ package co.nimblehq.template.xml.di.modules
 
 import co.nimblehq.template.xml.BuildConfig
 import co.nimblehq.template.xml.data.service.ApiService
+import co.nimblehq.template.xml.data.service.AuthService
 import co.nimblehq.template.xml.data.service.providers.ApiServiceProvider
 import co.nimblehq.template.xml.data.service.providers.ConverterFactoryProvider
 import co.nimblehq.template.xml.data.service.providers.RetrofitProvider
+import co.nimblehq.template.xml.di.Authenticate
 import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
@@ -37,4 +39,21 @@ class RetrofitModule {
     @Provides
     fun provideApiService(retrofit: Retrofit): ApiService =
         ApiServiceProvider.getApiService(retrofit)
+
+
+    @Authenticate
+    @Provides
+    fun provideAuthRetrofit(
+        baseUrl: String,
+        @Authenticate okHttpClient: OkHttpClient,
+        converterFactory: Converter.Factory,
+    ): Retrofit = RetrofitProvider
+        .getRetrofitBuilder(baseUrl, okHttpClient, converterFactory)
+        .build()
+
+    @Provides
+    fun provideAuthService(
+        @Authenticate retrofit: Retrofit
+    ): AuthService =
+        ApiServiceProvider.getAuthService(retrofit)
 }

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/di/modules/RetrofitModule.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/di/modules/RetrofitModule.kt
@@ -40,7 +40,6 @@ class RetrofitModule {
     fun provideApiService(retrofit: Retrofit): ApiService =
         ApiServiceProvider.getApiService(retrofit)
 
-
     @Authenticate
     @Provides
     fun provideAuthRetrofit(
@@ -54,6 +53,5 @@ class RetrofitModule {
     @Provides
     fun provideAuthService(
         @Authenticate retrofit: Retrofit
-    ): AuthService =
-        ApiServiceProvider.getAuthService(retrofit)
+    ): AuthService = ApiServiceProvider.getAuthService(retrofit)
 }

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/extensions/ResponseMapping.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/extensions/ResponseMapping.kt
@@ -54,3 +54,15 @@ private fun parseErrorResponse(response: Response<*>?): ErrorResponse? {
         null
     }
 }
+
+fun parseErrorResponse(jsonString: String?): ErrorResponse? {
+    return try {
+        val moshi = MoshiBuilderProvider.moshiBuilder.build()
+        val adapter = moshi.adapter(ErrorResponse::class.java)
+        adapter.fromJson(jsonString.orEmpty())
+    } catch (exception: IOException) {
+        null
+    } catch (exception: JsonDataException) {
+        null
+    }
+}

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/repository/SessionManagerImpl.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/repository/SessionManagerImpl.kt
@@ -1,0 +1,19 @@
+package co.nimblehq.template.xml.data.repository
+
+import co.nimblehq.template.xml.data.response.AuthenticateResponse
+import co.nimblehq.template.xml.data.service.SessionManager
+
+class SessionManagerImpl: SessionManager {
+    
+    override suspend fun getAccessToken(): String {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getRefreshToken(): String {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun refresh(authenticateResponse: AuthenticateResponse) {
+        TODO("Not yet implemented")
+    }
+}

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/repository/TokenRefresherImpl.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/repository/TokenRefresherImpl.kt
@@ -1,0 +1,16 @@
+package co.nimblehq.template.xml.data.repository
+
+import co.nimblehq.template.xml.data.extensions.flowTransform
+import co.nimblehq.template.xml.data.response.AuthenticateResponse
+import co.nimblehq.template.xml.data.service.AuthService
+import co.nimblehq.template.xml.data.service.authenticator.TokenRefresher
+import kotlinx.coroutines.flow.Flow
+
+class TokenRefresherImpl constructor(
+    private val authService: AuthService
+) : TokenRefresher {
+
+    override suspend fun refreshToken(): Flow<AuthenticateResponse> = flowTransform {
+        authService.refreshToken()
+    }
+}

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/response/AuthenticateResponse.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/response/AuthenticateResponse.kt
@@ -1,0 +1,22 @@
+package co.nimblehq.template.xml.data.response
+
+import co.nimblehq.template.xml.domain.model.AuthStatus
+import com.squareup.moshi.Json
+
+data class AuthenticateResponse(
+    @Json(name = "access_token")
+    val accessToken: String,
+    @Json(name = "refresh_token")
+    val refreshToken: String,
+    @Json(name = "status")
+    val status: String,
+    @Json(name = "token_type")
+    val tokenType: String?
+)
+
+fun AuthenticateResponse.toAuthenticated() = AuthStatus.Authenticated(
+    accessToken = accessToken,
+    refreshToken = refreshToken,
+    status = status,
+    tokenType = tokenType
+)

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/response/ErrorResponse.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/response/ErrorResponse.kt
@@ -5,7 +5,9 @@ import com.squareup.moshi.Json
 
 data class ErrorResponse(
     @Json(name = "message")
-    val message: String
+    val message: String,
+    @Json(name = "type")
+    val type: String?
 )
 
-internal fun ErrorResponse.toModel() = Error(message = message)
+internal fun ErrorResponse.toModel() = Error(message = message, type = type)

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/AuthService.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/AuthService.kt
@@ -1,0 +1,10 @@
+package co.nimblehq.template.xml.data.service
+
+import co.nimblehq.template.xml.data.response.AuthenticateResponse
+import retrofit2.http.POST
+
+interface AuthService {
+
+    @POST("refreshToken")
+    suspend fun refreshToken(): AuthenticateResponse
+}

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/SessionManager.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/SessionManager.kt
@@ -1,0 +1,12 @@
+package co.nimblehq.template.xml.data.service
+
+import co.nimblehq.template.xml.data.response.AuthenticateResponse
+
+interface SessionManager {
+
+    suspend fun getAccessToken(): String
+
+    suspend fun getRefreshToken(): String
+
+    suspend fun refresh(authenticateResponse: AuthenticateResponse)
+}

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/authenticator/ApplicationRequestAuthenticator.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/authenticator/ApplicationRequestAuthenticator.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.last
 import okhttp3.*
 
 const val REQUEST_HEADER_AUTHORIZATION = "Authorization"
+const val HEADER_AUTHENTICATION_SKIPPING_ERROR_TYPE = "Authentication-Skipping-ErrorType"
+private const val MAX_ATTEMPTS = 3
 
 class ApplicationRequestAuthenticator(
     private val tokenRefresher: TokenRefresher,
@@ -88,6 +90,3 @@ class ApplicationRequestAuthenticator(
         return false
     }
 }
-
-const val HEADER_AUTHENTICATION_SKIPPING_ERROR_TYPE = "Authentication-Skipping-ErrorType"
-private const val MAX_ATTEMPTS = 3

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/authenticator/ApplicationRequestAuthenticator.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/authenticator/ApplicationRequestAuthenticator.kt
@@ -1,0 +1,93 @@
+package co.nimblehq.template.xml.data.service.authenticator
+
+import android.annotation.SuppressLint
+import android.util.Log
+import co.nimblehq.template.xml.data.extensions.parseErrorResponse
+import co.nimblehq.template.xml.data.service.SessionManager
+import co.nimblehq.template.xml.domain.exceptions.NoConnectivityException
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.last
+import okhttp3.*
+
+const val REQUEST_HEADER_AUTHORIZATION = "Authorization"
+
+class ApplicationRequestAuthenticator(
+    private val tokenRefresher: TokenRefresher,
+    private val sessionManager: SessionManager
+) : Authenticator {
+
+    lateinit var okHttpClient: OkHttpClient
+
+    private var retryCount = 0
+
+    @SuppressLint("CheckResult", "LongMethod", "TooGenericExceptionCaught")
+    override fun authenticate(route: Route?, response: Response): Request? =
+        runBlocking {
+            if (shouldSkipAuthenticationByErrorType(response)) {
+                return@runBlocking null
+            }
+
+            // Due to unable to check the last retry succeeded
+            // So reset the retry count on the request first triggered by an automatic retry
+            if (response.priorResponse == null && retryCount != 0) {
+                retryCount = 0
+            }
+
+            if (retryCount >= MAX_ATTEMPTS) {
+                // Reset retry count once reached max attempts
+                retryCount = 0
+                return@runBlocking null
+            } else {
+                retryCount++
+
+                val failedAccessToken = sessionManager.getAccessToken()
+
+                try {
+                    val refreshTokenResponse = tokenRefresher.refreshToken().last()
+                    val newAccessToken = refreshTokenResponse.accessToken
+
+                    if (newAccessToken.isEmpty() || newAccessToken == failedAccessToken) {
+                        // Avoid infinite loop if the new Token == old (failed) token
+                        return@runBlocking null
+                    }
+
+                    // Update the Interceptor (for future requests)
+                    sessionManager.refresh(refreshTokenResponse)
+
+                    // Retry this failed request (401) with the new token
+                    return@runBlocking response.request
+                        .newBuilder()
+                        .header(REQUEST_HEADER_AUTHORIZATION, newAccessToken)
+                        .build()
+                } catch (e: Exception) {
+                    Log.w("AUTHENTICATOR", "Failed to refresh token: $e")
+                    return@runBlocking if (e !is NoConnectivityException) {
+                        // cancel all pending requests
+                        okHttpClient.dispatcher.cancelAll()
+                        response.request
+                    } else {
+                        // do nothing
+                        null
+                    }
+                }
+            }
+        }
+
+    private fun shouldSkipAuthenticationByErrorType(response: Response): Boolean {
+        val headers = response.request.headers
+        val skippingError = headers[HEADER_AUTHENTICATION_SKIPPING_ERROR_TYPE]
+
+        if (!skippingError.isNullOrEmpty()) {
+            // Clone response body
+            // https://github.com/square/okhttp/issues/1240#issuecomment-330813274
+            val responseBody = response.peekBody(Long.MAX_VALUE).toString()
+            val error = parseErrorResponse(responseBody)
+
+            return error != null && skippingError == error.type
+        }
+        return false
+    }
+}
+
+const val HEADER_AUTHENTICATION_SKIPPING_ERROR_TYPE = "Authentication-Skipping-ErrorType"
+private const val MAX_ATTEMPTS = 3

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/authenticator/TokenRefresher.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/authenticator/TokenRefresher.kt
@@ -1,0 +1,9 @@
+package co.nimblehq.template.xml.data.service.authenticator
+
+import co.nimblehq.template.xml.data.response.AuthenticateResponse
+import kotlinx.coroutines.flow.Flow
+
+interface TokenRefresher {
+
+    suspend fun refreshToken(): Flow<AuthenticateResponse>
+}

--- a/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/providers/ApiServiceProvider.kt
+++ b/template-xml/data/src/main/java/co/nimblehq/template/xml/data/service/providers/ApiServiceProvider.kt
@@ -1,11 +1,16 @@
 package co.nimblehq.template.xml.data.service.providers
 
 import co.nimblehq.template.xml.data.service.ApiService
+import co.nimblehq.template.xml.data.service.AuthService
 import retrofit2.Retrofit
 
 object ApiServiceProvider {
 
     fun getApiService(retrofit: Retrofit): ApiService {
         return retrofit.create(ApiService::class.java)
+    }
+
+    fun getAuthService(retrofit: Retrofit): AuthService {
+        return retrofit.create(AuthService::class.java)
     }
 }

--- a/template-xml/data/src/test/java/co/nimblehq/template/xml/data/test/MockUtil.kt
+++ b/template-xml/data/src/test/java/co/nimblehq/template/xml/data/test/MockUtil.kt
@@ -27,6 +27,7 @@ object MockUtil {
         }
 
     val errorResponse = ErrorResponse(
-        message = "message"
+        message = "message",
+        type = null
     )
 }

--- a/template-xml/domain/src/main/java/co/nimblehq/template/xml/domain/model/AuthStatus.kt
+++ b/template-xml/domain/src/main/java/co/nimblehq/template/xml/domain/model/AuthStatus.kt
@@ -1,0 +1,11 @@
+package co.nimblehq.template.xml.domain.model
+
+sealed class AuthStatus {
+
+    data class Authenticated(
+        val accessToken: String,
+        val refreshToken: String,
+        val status: String,
+        val tokenType: String?
+    )
+}

--- a/template-xml/domain/src/main/java/co/nimblehq/template/xml/domain/model/Error.kt
+++ b/template-xml/domain/src/main/java/co/nimblehq/template/xml/domain/model/Error.kt
@@ -1,5 +1,6 @@
 package co.nimblehq.template.xml.domain.model
 
 data class Error(
-    val message: String
+    val message: String,
+    val type: String?
 )


### PR DESCRIPTION
## Why

Most of apps use API request and have `refresh token` mechanism to request new access token in case of expired. We don't have the setup for the initial `TokenAuthenticator` yet so we should add it into our templates.

## Who Benefits?

`Developers` who use this template to initialize their project with network request.

I think this is **essential** because most of apps have API request and have refresh token mechanism. Having a standard setup would help us a lot in development and reduce mistakes.

Example of implementation: https://github.com/nimblehq/toyota-wallet-android/blob/main/data/src/main/java/co/omise/gcpf/service/authenticator/ApplicationRequestAuthenticator.kt
