### PR TITLE
[#299] [Sample] Add UI tests for XML sample code

### DIFF
--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/extension/NavArgsExt.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/extension/NavArgsExt.kt
@@ -1,0 +1,10 @@
+package co.nimblehq.sample.xml.extension
+
+import androidx.annotation.MainThread
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavArgs
+import androidx.navigation.fragment.navArgs
+
+@MainThread
+inline fun <reified Args : NavArgs> Fragment.provideNavArgs(): Lazy<Args> =
+    OverridableLazy(navArgs())

--- a/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/second/SecondFragment.kt
+++ b/sample-xml/app/src/main/java/co/nimblehq/sample/xml/ui/screens/second/SecondFragment.kt
@@ -3,9 +3,9 @@ package co.nimblehq.sample.xml.ui.screens.second
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
-import androidx.navigation.fragment.navArgs
 import co.nimblehq.sample.xml.R
 import co.nimblehq.sample.xml.databinding.FragmentSecondBinding
+import co.nimblehq.sample.xml.extension.provideNavArgs
 import co.nimblehq.sample.xml.extension.provideViewModels
 import co.nimblehq.sample.xml.ui.base.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -14,7 +14,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class SecondFragment : BaseFragment<FragmentSecondBinding>() {
 
     private val viewModel: SecondViewModel by provideViewModels()
-    private val args: SecondFragmentArgs by navArgs()
+    private val args: SecondFragmentArgs by provideNavArgs()
 
     override val bindingInflater: (LayoutInflater, ViewGroup?, Boolean) -> FragmentSecondBinding
         get() = { inflater, container, attachToParent ->

--- a/sample-xml/app/src/test/java/co/nimblehq/sample/xml/test/NavArgsExt.kt
+++ b/sample-xml/app/src/test/java/co/nimblehq/sample/xml/test/NavArgsExt.kt
@@ -1,0 +1,14 @@
+package co.nimblehq.sample.xml.test
+
+import androidx.navigation.NavArgs
+import co.nimblehq.sample.xml.extension.OverridableLazy
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.isAccessible
+
+fun <Arg : NavArgs, T> T.replace(
+    argumentDelegate: KProperty1<T, Arg>,
+    argument: Arg
+) {
+    argumentDelegate.isAccessible = true
+    (argumentDelegate.getDelegate(this) as OverridableLazy<Arg>).implementation = lazy { argument }
+}

--- a/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/home/HomeFragmentTest.kt
+++ b/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/home/HomeFragmentTest.kt
@@ -1,4 +1,4 @@
-package co.nimblehq.sample.xml.ui.screens.xml
+package co.nimblehq.sample.xml.ui.screens.home
 
 import androidx.core.view.isVisible
 import co.nimblehq.sample.xml.databinding.FragmentHomeBinding
@@ -8,8 +8,6 @@ import co.nimblehq.sample.xml.test.getPrivateProperty
 import co.nimblehq.sample.xml.test.replace
 import co.nimblehq.sample.xml.ui.BaseFragmentTest
 import co.nimblehq.sample.xml.ui.base.NavigationEvent
-import co.nimblehq.sample.xml.ui.screens.home.HomeFragment
-import co.nimblehq.sample.xml.ui.screens.home.HomeViewModel
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.kotest.matchers.booleans.shouldBeFalse

--- a/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/second/SecondFragmentTest.kt
+++ b/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/second/SecondFragmentTest.kt
@@ -1,0 +1,65 @@
+package co.nimblehq.sample.xml.ui.screens.second
+
+import androidx.core.view.isVisible
+import co.nimblehq.sample.xml.R
+import co.nimblehq.sample.xml.databinding.FragmentSecondBinding
+import co.nimblehq.sample.xml.model.UiModel
+import co.nimblehq.sample.xml.test.getPrivateProperty
+import co.nimblehq.sample.xml.test.replace
+import co.nimblehq.sample.xml.ui.BaseFragmentTest
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.*
+import java.util.*
+
+@HiltAndroidTest
+class SecondFragmentTest : BaseFragmentTest<SecondFragment, FragmentSecondBinding>() {
+
+    private val mockViewModel = mockk<SecondViewModel>(relaxed = true)
+    private val mockArgs = mockk<SecondFragmentArgs>(relaxed = true)
+
+    private val uiModel = UiModel(UUID.randomUUID().toString())
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+
+        every { mockArgs.uiModel } returns uiModel
+    }
+
+    @Test
+    fun `When initializing fragment, it displays the text view`() {
+        launchFragment()
+        fragment.binding.tvSecondId.isVisible.shouldBeTrue()
+    }
+
+    @Test
+    fun `When initializing fragment and view model with id, it displays the text view with id content`() {
+        every { mockViewModel.id } returns MutableStateFlow(uiModel.id)
+
+        launchFragment()
+        fragment.binding.tvSecondId.text shouldBe fragment.getString(
+            R.string.second_id_title,
+            uiModel.id
+        )
+    }
+
+    private fun launchFragment() {
+        launchFragmentInHiltContainer<SecondFragment>(
+            onInstantiate = {
+                replace(getPrivateProperty("viewModel"), mockViewModel)
+                replace(getPrivateProperty("args"), mockArgs)
+            }
+        ) {
+            fragment = this
+        }
+    }
+}

--- a/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/second/SecondFragmentTest.kt
+++ b/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/second/SecondFragmentTest.kt
@@ -29,7 +29,7 @@ class SecondFragmentTest : BaseFragmentTest<SecondFragment, FragmentSecondBindin
     var hiltRule = HiltAndroidRule(this)
 
     @Before
-    fun setup() {
+    fun setUp() {
         hiltRule.inject()
 
         every { mockArgs.uiModel } returns uiModel

--- a/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/second/SecondFragmentTest.kt
+++ b/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/second/SecondFragmentTest.kt
@@ -36,13 +36,13 @@ class SecondFragmentTest : BaseFragmentTest<SecondFragment, FragmentSecondBindin
     }
 
     @Test
-    fun `When initializing fragment, it displays the text view`() {
+    fun `When launching fragment, it displays the text view`() {
         launchFragment()
         fragment.binding.tvSecondId.isVisible.shouldBeTrue()
     }
 
     @Test
-    fun `When initializing fragment and view model with id, it displays the text view with id content`() {
+    fun `When launching fragment and view model with id, it displays the text view with id content`() {
         every { mockViewModel.id } returns MutableStateFlow(uiModel.id)
 
         launchFragment()

--- a/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
+++ b/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
@@ -79,6 +79,14 @@ class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
     }
 
     @Test
+    fun `When launching fragment and view model does not emit first time launch, it does not display a toast message`() {
+        every { mockViewModel.isFirstTimeLaunch } returns MutableStateFlow(false)
+
+        launchFragment()
+        ShadowToast.getTextOfLatestToast() shouldBe null
+    }
+
+    @Test
     fun `When view model emits navigation event to second fragment, it should navigate to second screen`() {
         val uiModel = UiModel(UUID.randomUUID().toString())
         every { mockViewModel.navigator } returns MutableStateFlow(NavigationEvent.Second(uiModel))

--- a/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
+++ b/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
@@ -67,7 +67,7 @@ class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
         every { mockViewModel.uiModels } returns MutableStateFlow(items)
 
         launchFragment()
-        fragment.binding.rvHome.adapter?.itemCount shouldBe 3
+        fragment.binding.rvHome.adapter?.itemCount shouldBe items.size
     }
 
     @Test

--- a/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
+++ b/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
@@ -36,13 +36,13 @@ class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
     }
 
     @Test
-    fun `When initializing fragment, it displays the recycler view`() {
+    fun `When launching fragment, it displays the recycler view`() {
         launchFragment()
         fragment.binding.rvHome.isVisible.shouldBeTrue()
     }
 
     @Test
-    fun `When initializing fragment and view model emits loading, it displays the progress bar`() {
+    fun `When launching fragment and view model emits loading, it displays the progress bar`() {
         every { mockViewModel.isLoading } returns MutableStateFlow(true)
 
         launchFragment()
@@ -50,7 +50,7 @@ class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
     }
 
     @Test
-    fun `When initializing fragment and view model does not emit loading, it does not display the progress bar`() {
+    fun `When launching fragment and view model does not emit loading, it does not display the progress bar`() {
         every { mockViewModel.isLoading } returns MutableStateFlow(false)
 
         launchFragment()
@@ -58,7 +58,7 @@ class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
     }
 
     @Test
-    fun `When initializing fragment and view model emits list of item, it displays the recycler view with items`() {
+    fun `When launching fragment and view model emits list of item, it displays the recycler view with items`() {
         val items = arrayListOf(
             UiModel(UUID.randomUUID().toString()),
             UiModel(UUID.randomUUID().toString()),
@@ -71,7 +71,7 @@ class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
     }
 
     @Test
-    fun `When initializing fragment and view model emits first time launch, it displays a toast message`() {
+    fun `When launching fragment and view model emits first time launch, it displays a toast message`() {
         every { mockViewModel.isFirstTimeLaunch } returns MutableStateFlow(true)
 
         launchFragment()

--- a/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
+++ b/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
@@ -31,7 +31,7 @@ class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
     var hiltRule = HiltAndroidRule(this)
 
     @Before
-    fun setup() {
+    fun setUp() {
         hiltRule.inject()
     }
 
@@ -79,7 +79,7 @@ class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
     }
 
     @Test
-    fun `When view model emits navigation to second fragment, it should navigate to second screen`() {
+    fun `When view model emits navigation event to second fragment, it should navigate to second screen`() {
         val uiModel = UiModel(UUID.randomUUID().toString())
         every { mockViewModel.navigator } returns MutableStateFlow(NavigationEvent.Second(uiModel))
         every { mockMainNavigator.navigate(any()) } returns Unit

--- a/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
+++ b/sample-xml/app/src/test/java/co/nimblehq/sample/xml/ui/screens/xml/HomeFragmentTest.kt
@@ -2,17 +2,25 @@ package co.nimblehq.sample.xml.ui.screens.xml
 
 import androidx.core.view.isVisible
 import co.nimblehq.sample.xml.databinding.FragmentHomeBinding
+import co.nimblehq.sample.xml.model.UiModel
 import co.nimblehq.sample.xml.test.TestNavigatorModule.mockMainNavigator
 import co.nimblehq.sample.xml.test.getPrivateProperty
 import co.nimblehq.sample.xml.test.replace
 import co.nimblehq.sample.xml.ui.BaseFragmentTest
+import co.nimblehq.sample.xml.ui.base.NavigationEvent
 import co.nimblehq.sample.xml.ui.screens.home.HomeFragment
 import co.nimblehq.sample.xml.ui.screens.home.HomeViewModel
-import dagger.hilt.android.testing.*
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldNotBeNull
-import io.mockk.mockk
+import io.kotest.matchers.shouldBe
+import io.mockk.*
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.*
+import org.robolectric.shadows.ShadowToast
+import java.util.*
 
 @HiltAndroidTest
 class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
@@ -31,6 +39,53 @@ class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
     fun `When initializing fragment, it displays the recycler view`() {
         launchFragment()
         fragment.binding.rvHome.isVisible.shouldBeTrue()
+    }
+
+    @Test
+    fun `When initializing fragment and view model emits loading, it displays the progress bar`() {
+        every { mockViewModel.isLoading } returns MutableStateFlow(true)
+
+        launchFragment()
+        fragment.binding.pbHome.isVisible.shouldBeTrue()
+    }
+
+    @Test
+    fun `When initializing fragment and view model does not emit loading, it does not display the progress bar`() {
+        every { mockViewModel.isLoading } returns MutableStateFlow(false)
+
+        launchFragment()
+        fragment.binding.pbHome.isVisible.shouldBeFalse()
+    }
+
+    @Test
+    fun `When initializing fragment and view model emits list of item, it displays the recycler view with items`() {
+        val items = arrayListOf(
+            UiModel(UUID.randomUUID().toString()),
+            UiModel(UUID.randomUUID().toString()),
+            UiModel(UUID.randomUUID().toString())
+        )
+        every { mockViewModel.uiModels } returns MutableStateFlow(items)
+
+        launchFragment()
+        fragment.binding.rvHome.adapter?.itemCount shouldBe 3
+    }
+
+    @Test
+    fun `When initializing fragment and view model emits first time launch, it displays a toast message`() {
+        every { mockViewModel.isFirstTimeLaunch } returns MutableStateFlow(true)
+
+        launchFragment()
+        ShadowToast.getTextOfLatestToast() shouldBe "This is the first time launch"
+    }
+
+    @Test
+    fun `When view model emits navigation to second fragment, it should navigate to second screen`() {
+        val uiModel = UiModel(UUID.randomUUID().toString())
+        every { mockViewModel.navigator } returns MutableStateFlow(NavigationEvent.Second(uiModel))
+        every { mockMainNavigator.navigate(any()) } returns Unit
+
+        launchFragment()
+        verify { mockMainNavigator.navigate(NavigationEvent.Second(uiModel)) }
     }
 
     private fun launchFragment() {

--- a/template-xml/app/src/main/java/co/nimblehq/template/xml/extension/NavArgsExt.kt
+++ b/template-xml/app/src/main/java/co/nimblehq/template/xml/extension/NavArgsExt.kt
@@ -1,0 +1,10 @@
+package co.nimblehq.template.xml.extension
+
+import androidx.annotation.MainThread
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavArgs
+import androidx.navigation.fragment.navArgs
+
+@MainThread
+inline fun <reified Args : NavArgs> Fragment.provideNavArgs(): Lazy<Args> =
+    OverridableLazy(navArgs())

--- a/template-xml/app/src/test/java/co/nimblehq/template/xml/test/NavArgsExt.kt
+++ b/template-xml/app/src/test/java/co/nimblehq/template/xml/test/NavArgsExt.kt
@@ -1,0 +1,14 @@
+package co.nimblehq.template.xml.test
+
+import androidx.navigation.NavArgs
+import co.nimblehq.template.xml.extension.OverridableLazy
+import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.isAccessible
+
+fun <Arg : NavArgs, T> T.replace(
+    argumentDelegate: KProperty1<T, Arg>,
+    argument: Arg
+) {
+    argumentDelegate.isAccessible = true
+    (argumentDelegate.getDelegate(this) as OverridableLazy<Arg>).implementation = lazy { argument }
+}

--- a/template-xml/app/src/test/java/co/nimblehq/template/xml/ui/screens/home/HomeFragmentTest.kt
+++ b/template-xml/app/src/test/java/co/nimblehq/template/xml/ui/screens/home/HomeFragmentTest.kt
@@ -26,7 +26,7 @@ class HomeFragmentTest : BaseFragmentTest<HomeFragment, FragmentHomeBinding>() {
     }
 
     @Test
-    fun `When initializing fragment, it displays the title correctly`() {
+    fun `When launching fragment, it displays the title correctly`() {
         launchFragment()
         fragment.binding.tvTitle.text.toString() shouldBe fragment.resources.getString(R.string.app_name)
     }


### PR DESCRIPTION
Close #299 

## What happened 👀

- Add UI test cases for `HomeFragment` and `SecondFragment`
- Create `provideNavArgs` extension function and integrate it in `SecondFragment`

## Insight 📝

- The `provideNavArgs` extension function mimics the behaviour of our `provideViewModel` so that we can easily mock the `navArgs` in the test

## Proof Of Work 📹

- Test case

<img width="700" alt="Screenshot 2023-04-24 at 3 46 22 PM" src="https://user-images.githubusercontent.com/25218255/233946097-64bfdcf0-c7da-4b68-b971-06e50493ab49.png">

<img width="700" alt="Screenshot 2023-03-30 at 4 36 36 PM" src="https://user-images.githubusercontent.com/25218255/228798285-ee12b1b4-c442-465c-b1ef-a71af11353eb.png">

- Code coverage

<img width="800" alt="Screenshot 2023-04-24 at 3 48 21 PM" src="https://user-images.githubusercontent.com/25218255/233946589-7ca9d404-9fbe-48f6-845f-142a55a6e133.png">

<img width="800" alt="Screenshot 2023-04-24 at 3 43 10 PM" src="https://user-images.githubusercontent.com/25218255/233946245-445615ac-eced-4a85-8c04-d3b21aa2d76c.png">
