### PR TITLE
[#455] Add checkout repository step to the workflow

### DIFF
--- a/.github/wiki/Home.md
+++ b/.github/wiki/Home.md
@@ -55,4 +55,4 @@ Before an issue can be worked on, it should go through our voting process.
 - If the majority vote to reject the issue, then the discussion is locked and no issue is created.
 - If the vote is tied, then the repository maintainer must resolve it.
 
-Still unsure where your future contribution belongs? Let's discuss! 🚀
+Still unsure where your future contribution belongs? Let's discuss! 🚀 

--- a/.github/wiki/Home.md
+++ b/.github/wiki/Home.md
@@ -55,4 +55,4 @@ Before an issue can be worked on, it should go through our voting process.
 - If the majority vote to reject the issue, then the discussion is locked and no issue is created.
 - If the vote is tied, then the repository maintainer must resolve it.
 
-Still unsure where your future contribution belongs? Let's discuss! 🚀 
+Still unsure where your future contribution belongs? Let's discuss! 🚀

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -6,13 +6,6 @@ on:
       - .github/wiki/**
     branches:
       - main
-      - bug/455-fix-publish-wiki-workflow
-
-  pull_request:
-    paths:
-      - .github/wiki/**
-    types: [ opened, reopened, synchronize, edited ]
-    branches: [ bug/455-fix-publish-wiki-workflow ]
 
 jobs:
   publish_docs_to_wiki:

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -6,13 +6,6 @@ on:
       - .github/wiki/**
     branches:
       - main
-      - bug/455-fix-publish-wiki-workflow
-
-  pull_request:
-    paths:
-      - .github/wiki/**
-    types: [ opened, reopened, synchronize, edited ]
-    branches: [ bug/455-fix-publish-wiki-workflow ]
 
 jobs:
   publish_docs_to_wiki:
@@ -30,7 +23,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Publish Github Wiki Documentation
+      - name: Publish Github Wiki
         uses: nimblehq/publish-github-wiki-action@v1.0
         with:
           user_name: team-nimblehq

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2.3.2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -8,6 +8,12 @@ on:
       - main
       - bug/455-fix-publish-wiki-workflow
 
+  pull_request:
+    paths:
+      - .github/wiki/**
+    types: [ opened, reopened, synchronize, edited ]
+    branches: [ bug/455-fix-publish-wiki-workflow ]
+
 jobs:
   publish_docs_to_wiki:
     name: Publish docs to Wiki
@@ -24,7 +30,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Publish Github Wiki
+      - name: Publish Github Wiki Documentation
         uses: nimblehq/publish-github-wiki-action@v1.0
         with:
           user_name: team-nimblehq

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -6,6 +6,7 @@ on:
       - .github/wiki/**
     branches:
       - main
+      - bug/455-fix-publish-wiki-workflow
 
 jobs:
   publish_docs_to_wiki:
@@ -13,6 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout the repository
+        uses: actions/checkout@v2.3.2
+        with:
+          ref: ${{ github.head_ref }}
+
       - name: Publish Github Wiki
         uses: nimblehq/publish-github-wiki-action@v1.0
         with:

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -13,12 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ github.token }}
-
-      - name: Checkout the repository
+      - name: Check out the repository
         uses: actions/checkout@v2.3.2
         with:
           ref: ${{ github.head_ref }}

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -6,6 +6,13 @@ on:
       - .github/wiki/**
     branches:
       - main
+      - bug/455-fix-publish-wiki-workflow
+
+  pull_request:
+    paths:
+      - .github/wiki/**
+    types: [ opened, reopened, synchronize, edited ]
+    branches: [ bug/455-fix-publish-wiki-workflow ]
 
 jobs:
   publish_docs_to_wiki:


### PR DESCRIPTION
- Closes #455 

## What happened 👀

As discussed in [this thread](https://nimble-co.slack.com/archives/CSQG2QXFX/p1680670636485339?thread_ts=1680669140.429079&cid=CSQG2QXFX):
- Added `Checkout the repository` step to our `publish-wiki-workflow`

## Insight 📝

- The Github wiki repo is using `master` branch by default (Check out [here](https://github.com/orgs/community/discussions/48537)), not `main` as our repository. So in this case, we need to push the wiki content to the `master` branch as the script does correctly. ✅ 

## Proof Of Work 📹

After running the workflow with additional steps, Wiki page has been updated:

![Screenshot 2566-04-05 at 12 43 20 PM](https://user-images.githubusercontent.com/12026942/229992289-f0d555c9-0c07-4665-84f6-68d071a6729a.png)

