### PR TITLE
[#465] [Compose] Optimize to test "SharedFlow" execution in Composable with Robolectric

### DIFF
--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/base/BaseViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/base/BaseViewModel.kt
@@ -17,8 +17,8 @@ abstract class BaseViewModel : ViewModel() {
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<IsLoading> = _isLoading
 
-    protected val _error = MutableStateFlow<Throwable?>(null)
-    val error: StateFlow<Throwable?> = _error
+    protected val _error = MutableSharedFlow<Throwable>()
+    val error: SharedFlow<Throwable> = _error
 
     protected val _navigator = MutableSharedFlow<AppDestination>()
     val navigator: SharedFlow<AppDestination> = _navigator

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
@@ -28,15 +28,14 @@ fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel(),
     navigator: (destination: AppDestination) -> Unit,
 ) {
+    val context = LocalContext.current
+    viewModel.error.collectAsEffect { e -> e.showToast(context) }
     viewModel.navigator.collectAsEffect { destination -> navigator(destination) }
 
     val isLoading: IsLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val uiModels: List<UiModel> by viewModel.uiModels.collectAsStateWithLifecycle()
     val isFirstTimeLaunch: Boolean by viewModel.isFirstTimeLaunch.collectAsStateWithLifecycle()
 
-    val context = LocalContext.current
-    val error: Throwable? by viewModel.error.collectAsStateWithLifecycle()
-    error?.showToast(context)
     LaunchedEffect(isFirstTimeLaunch) {
         if (isFirstTimeLaunch) {
             context.showToast("This is the first time launch")

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/test/CoroutineTestRule.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/test/CoroutineTestRule.kt
@@ -8,7 +8,7 @@ import org.junit.runner.Description
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CoroutineTestRule(
-    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+    var testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
 ) : TestWatcher() {
 
     val testDispatcherProvider = object : DispatchersProvider {

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/BaseScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/BaseScreenTest.kt
@@ -1,0 +1,17 @@
+package co.nimblehq.sample.compose.ui.screens
+
+import co.nimblehq.sample.compose.test.CoroutineTestRule
+import kotlinx.coroutines.test.StandardTestDispatcher
+
+abstract class BaseScreenTest {
+
+    protected val coroutinesRule = CoroutineTestRule()
+
+    protected fun setStandardTestDispatcher() {
+        coroutinesRule.testDispatcher = StandardTestDispatcher()
+    }
+
+    protected fun advanceUntilIdle() {
+        coroutinesRule.testDispatcher.scheduler.advanceUntilIdle()
+    }
+}

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -9,8 +9,8 @@ import androidx.test.rule.GrantPermissionRule
 import co.nimblehq.sample.compose.R
 import co.nimblehq.sample.compose.domain.model.Model
 import co.nimblehq.sample.compose.domain.usecase.*
-import co.nimblehq.sample.compose.test.CoroutineTestRule
 import co.nimblehq.sample.compose.ui.AppDestination
+import co.nimblehq.sample.compose.ui.screens.BaseScreenTest
 import co.nimblehq.sample.compose.ui.screens.MainActivity
 import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 import io.kotest.matchers.shouldBe
@@ -26,9 +26,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowToast
 
 @RunWith(RobolectricTestRunner::class)
-class HomeScreenTest {
-
-    private val coroutinesRule = CoroutineTestRule()
+class HomeScreenTest : BaseScreenTest() {
 
     @get:Rule
     val composeRule = createAndroidComposeRule<MainActivity>()
@@ -56,8 +54,6 @@ class HomeScreenTest {
             listOf(Model(1), Model(2), Model(3))
         )
         every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(false)
-
-        initViewModel()
     }
 
     @Test
@@ -72,15 +68,14 @@ class HomeScreenTest {
 
     @Test
     fun `When entering the Home screen and loading the list item failure, it shows the corresponding error`() {
-        coroutinesRule.testDispatcher = StandardTestDispatcher()
+        setStandardTestDispatcher()
 
         val error = Exception()
         every { mockGetModelsUseCase() } returns flow { throw error }
-        initViewModel()
 
         initComposable {
             composeRule.waitForIdle()
-            coroutinesRule.testDispatcher.scheduler.advanceUntilIdle()
+            advanceUntilIdle()
 
             ShadowToast.showedToast(activity.getString(R.string.error_generic)) shouldBe true
         }
@@ -96,6 +91,8 @@ class HomeScreenTest {
     private fun initComposable(
         testBody: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>.() -> Unit,
     ) {
+        initViewModel()
+
         composeRule.activity.setContent {
             ComposeTheme {
                 HomeScreen(

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -42,8 +42,10 @@ class HomeScreenTest {
     )
 
     private val mockGetModelsUseCase: GetModelsUseCase = mockk()
-    private val mockIsFirstTimeLaunchPreferencesUseCase: IsFirstTimeLaunchPreferencesUseCase = mockk()
-    private val mockUpdateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase = mockk()
+    private val mockIsFirstTimeLaunchPreferencesUseCase: IsFirstTimeLaunchPreferencesUseCase =
+        mockk()
+    private val mockUpdateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase =
+        mockk()
 
     private lateinit var viewModel: HomeViewModel
     private var expectedAppDestination: AppDestination? = null
@@ -70,12 +72,15 @@ class HomeScreenTest {
 
     @Test
     fun `When entering the Home screen and loading the list item failure, it shows the corresponding error`() {
+        coroutinesRule.testDispatcher = StandardTestDispatcher()
+
         val error = Exception()
         every { mockGetModelsUseCase() } returns flow { throw error }
         initViewModel()
 
         initComposable {
-            onNodeWithText("Home").assertIsDisplayed()
+            composeRule.waitForIdle()
+            coroutinesRule.testDispatcher.scheduler.advanceUntilIdle()
 
             ShadowToast.showedToast(activity.getString(R.string.error_generic)) shouldBe true
         }
@@ -89,13 +94,13 @@ class HomeScreenTest {
     }
 
     private fun initComposable(
-        testBody: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>.() -> Unit
+        testBody: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>.() -> Unit,
     ) {
         composeRule.activity.setContent {
             ComposeTheme {
                 HomeScreen(
                     viewModel = viewModel,
-                    navigator = { destination -> expectedAppDestination = destination }
+                    navigator = { destination -> expectedAppDestination = destination },
                 )
             }
         }

--- a/sample-compose/buildSrc/src/main/java/Versions.kt
+++ b/sample-compose/buildSrc/src/main/java/Versions.kt
@@ -9,17 +9,16 @@ object Versions {
     const val ANDROID_VERSION_NAME = "3.19.0"
 
     // Dependencies (Alphabet sorted)
-    const val ACCOMPANIST_PERMISSIONS_VERSION = "0.28.0"
+    const val ACCOMPANIST_PERMISSIONS_VERSION = "0.30.1"
     const val ANDROID_COMMON_KTX_VERSION = "0.1.1"
     const val ANDROID_CRYPTO_VERSION = "1.0.0"
-    const val ANDROIDX_CORE_KTX_VERSION = "1.9.0"
+    const val ANDROIDX_CORE_KTX_VERSION = "1.10.1"
     const val ANDROIDX_DATASTORE_PREFERENCES_VERSION = "1.0.0"
-    const val ANDROIDX_LIFECYCLE_VERSION = "2.6.0-rc01"
-    const val ANDROIDX_TEST_CORE_VERSION = "1.4.0"
+    const val ANDROIDX_LIFECYCLE_VERSION = "2.6.1"
 
     const val CHUCKER_VERSION = "3.5.2"
-    const val COMPOSE_BOM_VERSION = "2022.12.00"
-    const val COMPOSE_COMPILER_VERSION = "1.4.3"
+    const val COMPOSE_BOM_VERSION = "2023.04.01"
+    const val COMPOSE_COMPILER_VERSION = "1.4.7"
     const val COMPOSE_NAVIGATION_VERSION = "2.5.3"
 
     const val HILT_VERSION = "2.44"
@@ -27,8 +26,8 @@ object Versions {
 
     const val JAVAX_INJECT_VERSION = "1"
 
-    const val KOTLIN_VERSION = "1.8.10"
-    const val KOTLINX_COROUTINES_VERSION = "1.6.4"
+    const val KOTLIN_VERSION = "1.8.21"
+    const val KOTLINX_COROUTINES_VERSION = "1.7.1"
     const val KOVER_VERSION = "0.6.0"
 
     const val MOSHI_VERSION = "1.12.0"
@@ -43,10 +42,11 @@ object Versions {
     const val DETEKT_VERSION = "1.21.0"
 
     // Testing libraries
+    const val TEST_ANDROIDX_CORE_VERSION = "1.4.0"
     const val TEST_JUNIT_VERSION = "4.13.2"
-    const val TEST_KOTEST_VERSION = "5.5.4"
-    const val TEST_MOCKK_VERSION = "1.12.3"
-    const val TEST_ROBOLECTRIC_VERSION = "4.9.2"
+    const val TEST_KOTEST_VERSION = "5.6.2"
+    const val TEST_MOCKK_VERSION = "1.13.5"
+    const val TEST_ROBOLECTRIC_VERSION = "4.10.2"
     const val TEST_RULES_VERSION = "1.5.0"
-    const val TEST_TURBINE_VERSION = "0.12.1"
+    const val TEST_TURBINE_VERSION = "0.13.0"
 }

--- a/sample-compose/data/build.gradle.kts
+++ b/sample-compose/data/build.gradle.kts
@@ -81,7 +81,7 @@ dependencies {
     testImplementation("io.mockk:mockk:${Versions.TEST_MOCKK_VERSION}")
     testImplementation("io.kotest:kotest-assertions-core:${Versions.TEST_KOTEST_VERSION}")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.KOTLINX_COROUTINES_VERSION}")
-    testImplementation("androidx.test:core:${Versions.ANDROIDX_TEST_CORE_VERSION}")
+    testImplementation("androidx.test:core:${Versions.TEST_ANDROIDX_CORE_VERSION}")
     testImplementation("org.robolectric:robolectric:${Versions.TEST_ROBOLECTRIC_VERSION}")
     testImplementation("app.cash.turbine:turbine:${Versions.TEST_TURBINE_VERSION}")
 }

--- a/sample-compose/data/build.gradle.kts
+++ b/sample-compose/data/build.gradle.kts
@@ -11,7 +11,6 @@ android {
         minSdk = Versions.ANDROID_MIN_SDK_VERSION
         targetSdk = Versions.ANDROID_TARGET_SDK_VERSION
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
 

--- a/template-compose/app/src/test/java/co/nimblehq/template/compose/test/CoroutineTestRule.kt
+++ b/template-compose/app/src/test/java/co/nimblehq/template/compose/test/CoroutineTestRule.kt
@@ -8,7 +8,7 @@ import org.junit.runner.Description
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CoroutineTestRule(
-    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+    var testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
 ) : TestWatcher() {
 
     val testDispatcherProvider = object : DispatchersProvider {

--- a/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/BaseScreenTest.kt
+++ b/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/BaseScreenTest.kt
@@ -1,0 +1,17 @@
+package co.nimblehq.template.compose.ui.screens
+
+import co.nimblehq.template.compose.test.CoroutineTestRule
+import kotlinx.coroutines.test.StandardTestDispatcher
+
+abstract class BaseScreenTest {
+
+    protected val coroutinesRule = CoroutineTestRule()
+
+    protected fun setStandardTestDispatcher() {
+        coroutinesRule.testDispatcher = StandardTestDispatcher()
+    }
+
+    protected fun advanceUntilIdle() {
+        coroutinesRule.testDispatcher.scheduler.advanceUntilIdle()
+    }
+}

--- a/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
+++ b/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
@@ -7,8 +7,8 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import co.nimblehq.template.compose.R
 import co.nimblehq.template.compose.domain.model.Model
 import co.nimblehq.template.compose.domain.usecase.UseCase
-import co.nimblehq.template.compose.test.CoroutineTestRule
 import co.nimblehq.template.compose.ui.AppDestination
+import co.nimblehq.template.compose.ui.screens.BaseScreenTest
 import co.nimblehq.template.compose.ui.screens.MainActivity
 import co.nimblehq.template.compose.ui.theme.ComposeTheme
 import io.kotest.matchers.shouldBe
@@ -23,9 +23,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowToast
 
 @RunWith(RobolectricTestRunner::class)
-class HomeScreenTest {
-
-    private val coroutinesRule = CoroutineTestRule()
+class HomeScreenTest : BaseScreenTest() {
 
     @get:Rule
     val composeRule = createAndroidComposeRule<MainActivity>()
@@ -40,8 +38,6 @@ class HomeScreenTest {
         every { mockUseCase() } returns flowOf(
             listOf(Model(1), Model(2), Model(3))
         )
-
-        initViewModel()
     }
 
     @Test
@@ -51,15 +47,14 @@ class HomeScreenTest {
 
     @Test
     fun `When entering the Home screen and loading the data failure, it shows the corresponding error`() {
-        coroutinesRule.testDispatcher = StandardTestDispatcher()
+        setStandardTestDispatcher()
 
         val error = Exception()
         every { mockUseCase() } returns flow { throw error }
-        initViewModel()
 
         initComposable {
             composeRule.waitForIdle()
-            coroutinesRule.testDispatcher.scheduler.advanceUntilIdle()
+            advanceUntilIdle()
 
             ShadowToast.showedToast(activity.getString(R.string.error_generic)) shouldBe true
         }
@@ -68,6 +63,8 @@ class HomeScreenTest {
     private fun initComposable(
         testBody: AndroidComposeTestRule<ActivityScenarioRule<MainActivity>, MainActivity>.() -> Unit,
     ) {
+        initViewModel()
+
         composeRule.activity.setContent {
             ComposeTheme {
                 HomeScreen(

--- a/template-compose/buildSrc/src/main/java/Versions.kt
+++ b/template-compose/buildSrc/src/main/java/Versions.kt
@@ -9,17 +9,16 @@ object Versions {
     const val ANDROID_VERSION_NAME = "1.0.0"
 
     // Dependencies (Alphabet sorted)
-    const val ACCOMPANIST_PERMISSIONS_VERSION = "0.28.0"
+    const val ACCOMPANIST_PERMISSIONS_VERSION = "0.30.1"
     const val ANDROID_COMMON_KTX_VERSION = "0.1.1"
     const val ANDROID_CRYPTO_VERSION = "1.0.0"
-    const val ANDROIDX_CORE_KTX_VERSION = "1.9.0"
+    const val ANDROIDX_CORE_KTX_VERSION = "1.10.1"
     const val ANDROIDX_DATASTORE_PREFERENCES_VERSION = "1.0.0"
-    const val ANDROIDX_LIFECYCLE_VERSION = "2.6.0-rc01"
-    const val ANDROIDX_TEST_CORE_VERSION = "1.4.0"
+    const val ANDROIDX_LIFECYCLE_VERSION = "2.6.1"
 
     const val CHUCKER_VERSION = "3.5.2"
-    const val COMPOSE_BOM_VERSION = "2022.12.00"
-    const val COMPOSE_COMPILER_VERSION = "1.4.3"
+    const val COMPOSE_BOM_VERSION = "2023.04.01"
+    const val COMPOSE_COMPILER_VERSION = "1.4.7"
     const val COMPOSE_NAVIGATION_VERSION = "2.5.3"
 
     const val HILT_VERSION = "2.44"
@@ -27,8 +26,8 @@ object Versions {
 
     const val JAVAX_INJECT_VERSION = "1"
 
-    const val KOTLIN_VERSION = "1.8.10"
-    const val KOTLINX_COROUTINES_VERSION = "1.6.4"
+    const val KOTLIN_VERSION = "1.8.21"
+    const val KOTLINX_COROUTINES_VERSION = "1.7.1"
     const val KOVER_VERSION = "0.6.0"
 
     const val MOSHI_VERSION = "1.12.0"
@@ -43,9 +42,10 @@ object Versions {
     const val DETEKT_VERSION = "1.21.0"
 
     // Testing libraries
+    const val TEST_ANDROIDX_CORE_VERSION = "1.4.0"
     const val TEST_JUNIT_VERSION = "4.13.2"
-    const val TEST_KOTEST_VERSION = "4.6.3"
-    const val TEST_MOCKK_VERSION = "1.13.3"
-    const val TEST_ROBOLECTRIC_VERSION = "4.9.2"
-    const val TEST_TURBINE_VERSION = "0.12.1"
+    const val TEST_KOTEST_VERSION = "5.6.2"
+    const val TEST_MOCKK_VERSION = "1.13.5"
+    const val TEST_ROBOLECTRIC_VERSION = "4.10.2"
+    const val TEST_TURBINE_VERSION = "0.13.0"
 }

--- a/template-compose/data/build.gradle.kts
+++ b/template-compose/data/build.gradle.kts
@@ -81,7 +81,7 @@ dependencies {
     testImplementation("io.mockk:mockk:${Versions.TEST_MOCKK_VERSION}")
     testImplementation("io.kotest:kotest-assertions-core:${Versions.TEST_KOTEST_VERSION}")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.KOTLINX_COROUTINES_VERSION}")
-    testImplementation("androidx.test:core:${Versions.ANDROIDX_TEST_CORE_VERSION}")
+    testImplementation("androidx.test:core:${Versions.TEST_ANDROIDX_CORE_VERSION}")
     testImplementation("org.robolectric:robolectric:${Versions.TEST_ROBOLECTRIC_VERSION}")
     testImplementation("app.cash.turbine:turbine:${Versions.TEST_TURBINE_VERSION}")
 }

--- a/template-compose/data/build.gradle.kts
+++ b/template-compose/data/build.gradle.kts
@@ -11,7 +11,6 @@ android {
         minSdk = Versions.ANDROID_MIN_SDK_VERSION
         targetSdk = Versions.ANDROID_TARGET_SDK_VERSION
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
 


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/465

## What happened 👀

- Research & find a valid way to [test SharedFlow execution in Composable with Robolectric without converting it to StateFlow](https://github.com/nimblehq/android-templates/pull/399/commits/60e64877ad732f5daef82e5bda19320fca75aad2). 
- Apply using `viewModel.error.collectAsEffect` for error handling.
- Define a `BaseScreenTest` as a helper to simplify the test logic for Compose.
- Update Compose & testing dependencies to latest versions 🚀 

## Insight 📝

- To assert a Toast from a SharedFlow execution in the ViewModel's `init` block with Robolectric, 
  - set [`coroutinesRule.testDispatcher = StandardTestDispatcher()`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-standard-test-dispatcher.html)
  - use `composeRule.waitForIdle()` to wait until the Compose view is ready
  - call [`advanceUntilIdle()`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-coroutine-scheduler/advance-until-idle.html) to trigger the execution before asserting.

- To simplify the preparation step, move `initViewModel()` into `initComposable()` to initialize ViewModel with necessary mocking before rendering the Composable.

## Proof Of Work 📹

- Template
![image](https://github.com/nimblehq/android-templates/assets/16315358/25a4387f-2204-4a33-aea1-f7abf175f50a)


- Sample
![image](https://github.com/nimblehq/android-templates/assets/16315358/0e424420-bb59-4bab-9f9c-7aaa0e4d29b2)
