### PR TITLE
[#464] [Compose] Update Kover's exclusion config

### DIFF
--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -81,6 +81,8 @@ koverMerged {
         "*.*_MembersInjector*",
         "*.*_Factory*",
         "*.Hilt_*",
+        "dagger.hilt.internal.*",
+        "hilt_aggregated_deps.*",
         // Jetpack Compose
         "*.ComposableSingletons*",
         "*.*\$*Preview\$*",

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -67,45 +67,26 @@ detekt {
 koverMerged {
     enable()
 
-    val generatedFiles = setOf(
-        "*.R.class",
-        "*.R\$*.class",
-        "*.*\$ViewBinder*.*",
-        "*.*\$InjectAdapter*.*",
-        "*.*Injector*.*",
+    val excludedFiles = listOf(
         "*.BuildConfig.*",
         "*.BuildConfig",
-        "*.Manifest*.*",
-        "*.*_ViewBinding*.*",
-        "*.*Adapter*.*",
-        "*.*Test*.*",
         // Enum
         "*.*\$Creator*",
-        // Nav Component
-        "*.*_Factory*",
-        "*.*FragmentArgs*",
-        "*.*FragmentDirections*",
-        "*.FragmentNavArgsLazy.kt",
-        "*.*Fragment*navArgs*",
-        "*.*ModuleDeps*.*",
-        "*.*NavGraphDirections*",
+        // DI
+        "*.di.*",
         // Hilt
         "*.*_ComponentTreeDeps*",
         "*.*_HiltComponents*",
         "*.*_HiltModules*",
         "*.*_MembersInjector*",
-        "*.Hilt_*"
+        "*.*_Factory*",
+        "*.Hilt_*",
+        // Jetpack Compose
+        "*.ComposableSingletons*",
+        "*.*\$*Preview\$*",
+        "*.ui.preview.*",
     )
 
-    val excludedPackages = setOf(
-        "com.bumptech.glide.*",
-        "dagger.hilt.internal.*",
-        "hilt_aggregated_deps.*",
-        "co.nimblehq.sample.compose.databinding.*",
-        "co.nimblehq.sample.compose.di.*"
-    )
-
-    val excludedFiles = generatedFiles + excludedPackages
     filters {
         classes {
             excludes += excludedFiles

--- a/template-compose/build.gradle.kts
+++ b/template-compose/build.gradle.kts
@@ -65,45 +65,26 @@ tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
 koverMerged {
     enable()
 
-    val generatedFiles = setOf(
-        "*.R.class",
-        "*.R\$*.class",
-        "*.*\$ViewBinder*.*",
-        "*.*\$InjectAdapter*.*",
-        "*.*Injector*.*",
+    val excludedFiles = listOf(
         "*.BuildConfig.*",
         "*.BuildConfig",
-        "*.Manifest*.*",
-        "*.*_ViewBinding*.*",
-        "*.*Adapter*.*",
-        "*.*Test*.*",
         // Enum
         "*.*\$Creator*",
-        // Nav Component
-        "*.*_Factory*",
-        "*.*FragmentArgs*",
-        "*.*FragmentDirections*",
-        "*.FragmentNavArgsLazy.kt",
-        "*.*Fragment*navArgs*",
-        "*.*ModuleDeps*.*",
-        "*.*NavGraphDirections*",
+        // DI
+        "*.di.*",
         // Hilt
         "*.*_ComponentTreeDeps*",
         "*.*_HiltComponents*",
         "*.*_HiltModules*",
         "*.*_MembersInjector*",
-        "*.Hilt_*"
+        "*.*_Factory*",
+        "*.Hilt_*",
+        // Jetpack Compose
+        "*.ComposableSingletons*",
+        "*.*\$*Preview\$*",
+        "*.ui.preview.*",
     )
 
-    val excludedPackages = setOf(
-        "com.bumptech.glide.*",
-        "dagger.hilt.internal.*",
-        "hilt_aggregated_deps.*",
-        "co.nimblehq.template.compose.databinding.*",
-        "co.nimblehq.template.compose.di.*"
-    )
-
-    val excludedFiles = generatedFiles + excludedPackages
     filters {
         classes {
             excludes += excludedFiles

--- a/template-compose/build.gradle.kts
+++ b/template-compose/build.gradle.kts
@@ -79,6 +79,8 @@ koverMerged {
         "*.*_MembersInjector*",
         "*.*_Factory*",
         "*.Hilt_*",
+        "dagger.hilt.internal.*",
+        "hilt_aggregated_deps.*",
         // Jetpack Compose
         "*.ComposableSingletons*",
         "*.*\$*Preview\$*",


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/464

## What happened 👀

Update Kover's exclusion config to 
- remove legacy XML method component exclusion config:
  - Redundant ViewBinding or DataBinding.
  - Redundant XML method components, e.g., Adapter, Dagger's generated code for XML.
  - Redundant Navigation Component.

- exclude Jetpack Compose generate code:
  - ComposableSingletons.
  - Previews.

## Insight 📝

It's not so clear to separate between `package` & `file` exclusion config now. We can just combine all into `excludedFiles`.

## Proof Of Work 📹

Updated Kover's code coverage report ✅ 

![image](https://github.com/nimblehq/android-templates/assets/16315358/c1ed215e-6eca-4b7f-9c66-53efbc3d681b)
