### PR TITLE
[#360] Migrate the deploy to Firebase workflow to use Service Account instead of Firebase Token

### DIFF
--- a/.cicdtemplate/.github/README.md
+++ b/.cicdtemplate/.github/README.md
@@ -6,4 +6,4 @@ The `.github` contains all the required setup for Github Action to trigger. Simp
 Here are the current Secrets we need to add to the Project Settings - Secret:
 
 - `FIREBASE_APP_ID_STAGING` - your application id on Firebase.
-- `FIREBASE_TOKEN` - your Firebase access/refresh token. Follow this [Guideline](https://firebase.google.com/docs/cli#cli-ci-systems) to get one for your project.
+- `FIREBASE_SERVICE_ACCOUNT_CREDENTIAL_FILE_CONTENT` - your Firebase service account credential file. Follow this [Guideline](https://github.com/wzieba/Firebase-Distribution-Github-Action/wiki/FIREBASE_TOKEN-migration#guide-2---the-same-but-with-screenshots) to get one for your project.

--- a/.cicdtemplate/.github/workflows/deploy_staging_and_production_to_firebase_app_distribution.yml
+++ b/.cicdtemplate/.github/workflows/deploy_staging_and_production_to_firebase_app_distribution.yml
@@ -63,7 +63,7 @@ jobs:
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: ${{secrets.FIREBASE_APP_ID_STAGING}}
-          token: ${{secrets.FIREBASE_TOKEN}}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIAL_FILE_CONTENT }}
           groups: testers
           file: app/build/outputs/apk/staging/debug/app-staging-debug.apk
 
@@ -74,6 +74,6 @@ jobs:
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: ${{secrets.FIREBASE_APP_ID_PRODUCTION}}
-          token: ${{secrets.FIREBASE_TOKEN}}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIAL_FILE_CONTENT }}
           groups: testers
           file: app/build/outputs/apk/production/debug/app-production-debug.apk

--- a/RxJavaTemplate[DEPRECATED]/fastlane/script/config.rb
+++ b/RxJavaTemplate[DEPRECATED]/fastlane/script/config.rb
@@ -39,7 +39,7 @@ module Config
     errors = []
     errors << verify_slack_config unless verify_slack_config.nil?
     errors << verify_workspace_config unless verify_workspace_config.nil?
-    errors << verify_firebase_token unless verify_firebase_token.nil?
+    errors << verify_service_account unless verify_service_account.nil?
     throw errors unless errors.empty?
   end
 
@@ -55,9 +55,9 @@ module Config
     'Missing env.WORKSPACE, please set it accordingly and retry'
   end
 
-  def verify_firebase_token
-    return unless ENV['FIREBASE_TOKEN'].nil?
+  def verify_service_account
+    return unless ENV['FIREBASE_SERVICE_ACCOUNT_CREDENTIAL_FILE_CONTENT'].nil?
 
-    'Missing env.FIREBASE_TOKEN for Firebase, please set it accordingly and retry'
+    'Missing env.FIREBASE_SERVICE_ACCOUNT_CREDENTIAL_FILE_CONTENT for Firebase App Distribution, please set it accordingly and retry'
   end
 end


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/360

## What happened 👀

Firebase CLI Tools announced the depreciation of token authentication in favor of Service Account ([source](https://github.com/firebase/firebase-tools#general)). This causes the action not to work properly anymore. We need to follow [this migration guide](https://github.com/wzieba/Firebase-Distribution-Github-Action/wiki/FIREBASE_TOKEN-migration) to migrate this action to use Service Account instead of Firebase Token.

## Insight 📝

Following the [migration guide](https://github.com/wzieba/Firebase-Distribution-Github-Action/wiki/FIREBASE_TOKEN-migration):
- Update the config in: `deploy_staging_and_production_to_firebase_app_distribution.yml` and `config.rb`
- Update README to refer migration guide for service account credential file

## Proof Of Work 📹

N/A
