### PR TITLE
[#428] [Chore] Update composables to have a Modifier parameter with default value

### DIFF
--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/AppBar.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/AppBar.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import co.nimblehq.sample.compose.R
@@ -11,8 +12,12 @@ import co.nimblehq.sample.compose.ui.theme.AppTheme.colors
 import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 
 @Composable
-fun AppBar(@StringRes title: Int) {
+fun AppBar(
+    @StringRes title: Int,
+    modifier: Modifier = Modifier,
+) {
     TopAppBar(
+        modifier = modifier,
         title = { Text(text = stringResource(title)) },
         backgroundColor = colors.topAppBarBackground
     )

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
@@ -17,12 +17,13 @@ import co.nimblehq.sample.compose.ui.theme.AppTheme.dimensions
 fun Item(
     uiModel: UiModel,
     onClick: (UiModel) -> Unit,
-    onLongClick: (UiModel) -> Unit
+    onLongClick: (UiModel) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .combinedClickable(
                 onClick = { onClick(uiModel) },

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import co.nimblehq.sample.compose.model.UiModel
 import co.nimblehq.sample.compose.ui.theme.ComposeTheme
@@ -12,9 +13,10 @@ import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 fun ItemList(
     uiModels: List<UiModel>,
     onItemClick: (UiModel) -> Unit,
-    onItemLongClick: (UiModel) -> Unit
+    onItemLongClick: (UiModel) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    LazyColumn {
+    LazyColumn(modifier) {
         items(uiModels) { uiModel ->
             Item(
                 uiModel = uiModel,


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/428

## What happened 👀

- [x] Update `template-compose` and `sample-compose` to add `modifier: Modifier = Modifier` to all composable functions that emit UI.
  - We do not need to add this to `Preview` composables.

## Insight 📝

Currently, we don't have a `subcomponent` of `composables` in `template-compose`. Therefore, we will update only in `sample-compose`.

## Proof Of Work 📹

N/A
