### PR TITLE
[#436] Add an argument to specify output folder location to new_project.kts script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ A collection of our Android templates:
     app-name=                          New app name (i.e., MyApp, "My App", "my-app")
     template=                          Template (i.e., xml, compose)
     force=                             Force project creation even if the script fails (default: false)
+    destination=                       Set the output location where the project should be generated (i.e., /Users/johndoe/documents/projectfolder)
   ```
 
   Examples: 
     `kscript new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml`
     `kscript scripts/new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml`
+    `kscript new_project.kts package-name=co.nimblehq.suvkmmsurveys.android app-name=Surveys template=compose destination=/Users/johndoe/documents/projectfolder`
 
 4. Update `android_version_code` and `android_version_name` in `template/build.gradle`
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A collection of our Android templates:
   Examples: 
     `kscript new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml`
     `kscript scripts/new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml`
-    `kscript new_project.kts package-name=co.nimblehq.suvkmmsurveys.android app-name=Surveys template=compose destination=/Users/johndoe/documents/projectfolder`
+    `kscript new_project.kts package-name=co.myxmlproject.example app-name="My XML Project" template=xml destination=/Users/johndoe/documents/projectfolder`
 
 4. Update `android_version_code` and `android_version_name` in `template/build.gradle`
 

--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -6,6 +6,7 @@ object NewProject {
     private const val DELIMITER_ARGUMENT = "="
 
     private const val KEY_APP_NAME = "app-name"
+    private const val KEY_DESTINATION = "destination"
     private const val KEY_FORCE = "force"
     private const val KEY_HELP = "--help"
     private const val KEY_PACKAGE_NAME = "package-name"
@@ -38,10 +39,12 @@ object NewProject {
             $KEY_APP_NAME=       New app name (i.e., MyApp, "My App", "my-app")
             $KEY_TEMPLATE=       Template (i.e., $TEMPLATE_XML, $TEMPLATE_COMPOSE)
             $KEY_FORCE=          Force project creation even if the script fails (default: false)
+            $KEY_DESTINATION=    Set the output location where the project should be generated (i.e., /Users/johndoe/documents/projectfolder)
         
         Examples:
             kscript new_project.kts $KEY_PACKAGE_NAME=co.myxmlproject.example $KEY_APP_NAME="My XML Project" $KEY_TEMPLATE=$TEMPLATE_XML
             kscript scripts/new_project.kts $KEY_PACKAGE_NAME=co.myxmlproject.example $KEY_APP_NAME="My XML Project" $KEY_TEMPLATE=$TEMPLATE_XML $KEY_FORCE=true
+            kscript scripts/new_project.kts $KEY_PACKAGE_NAME=co.myxmlproject.example $KEY_APP_NAME="My XML Project" $KEY_TEMPLATE=$TEMPLATE_XML $KEY_FORCE=true $KEY_DESTINATION=/Users/johndoe/documents/projectfolder
     """.trimIndent()
 
     private val modules = listOf("app", "data", "domain")
@@ -64,10 +67,12 @@ object NewProject {
 
     private var packageName = ""
 
+    private var destination = rootPath
+
     private var projectFolderName: String = ""
 
     private val projectPath: String
-        get() = rootPath + projectFolderName
+        get() = destination + projectFolderName
 
     private val rootPath: String
         get() = System.getProperty("user.dir").let { userDir ->
@@ -149,6 +154,10 @@ object NewProject {
                     val (key, value) = arg.split(DELIMITER_ARGUMENT)
                     forceProjectCreation = value.toBoolean()
                 }
+                arg.startsWith("$KEY_DESTINATION$DELIMITER_ARGUMENT") -> {
+                    val (key, value) = arg.split(DELIMITER_ARGUMENT)
+                    validateDestination(value)
+                }
                 else -> {
                     showMessage(
                         message = "ERROR: Invalid argument name: $arg \n$helpMessage",
@@ -207,6 +216,18 @@ object NewProject {
         } else {
             showMessage(
                 message = "Error: Invalid Template: $value (can either be $TEMPLATE_XML or $TEMPLATE_COMPOSE) \n$helpMessage",
+                exitAfterMessage = true,
+                isError = true,
+            )
+        }
+    }
+
+    private fun validateDestination(value: String) {
+        if (value.isNotBlank()) {
+            destination = "${value.trim()}$SEPARATOR_SLASH"
+        } else {
+            showMessage(
+                message = "Error: Invalid Destination: destination cannot be blank \n$helpMessage",
                 exitAfterMessage = true,
                 isError = true,
             )


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/436

## What happened 👀

* Add an argument destination that accepts a path to the generated project location
If no argument is given, default to the template root folder.
* `destination` must accept both absolute (`/Users/johndoe/documents/projectfolder`) and relative paths (`../projectfolder`).

## Insight 📝

* Added the argument.
* We only validate if the supplied argument is blank and show an error if that's the case. For any invalid path, the execution will fail on its own.

## Proof Of Work 📹


https://github.com/nimblehq/android-templates/assets/8093908/a01f9b0d-9374-4122-b851-eafe2d642928


