### PR TITLE
[#419] [Bug] Prevent the toast for first time app launch from reappearing after navigating back from the second screen

### DIFF
--- a/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/androidTest/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -46,10 +46,10 @@ class HomeScreenTest {
         every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(false)
 
         viewModel = HomeViewModel(
-            TestDispatchersProvider,
             mockGetModelsUseCase,
             mockIsFirstTimeLaunchPreferencesUseCase,
-            mockUpdateFirstTimeLaunchPreferencesUseCase
+            mockUpdateFirstTimeLaunchPreferencesUseCase,
+            TestDispatchersProvider
         )
     }
 

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
@@ -39,6 +39,7 @@ fun HomeScreen(
     LaunchedEffect(isFirstTimeLaunch) {
         if (isFirstTimeLaunch) {
             context.showToast("This is the first time launch")
+            viewModel.onFirstTimeLaunch()
         }
     }
 

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
@@ -38,7 +38,7 @@ fun HomeScreen(
 
     LaunchedEffect(isFirstTimeLaunch) {
         if (isFirstTimeLaunch) {
-            context.showToast("This is the first time launch")
+            context.showToast(context.getString(R.string.message_first_time_launch))
             viewModel.onFirstTimeLaunch()
         }
     }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
@@ -38,13 +38,13 @@ class HomeViewModel @Inject constructor(
             .catch { e -> _error.emit(e) }
             .launchIn(viewModelScope)
 
-        launch(dispatchersProvider.io) {
-            val isFirstTimeLaunch = isFirstTimeLaunchPreferencesUseCase()
-                .catch { e -> _error.emit(e) }
-                .first()
-
-            _isFirstTimeLaunch.emit(isFirstTimeLaunch)
-        }
+        isFirstTimeLaunchPreferencesUseCase()
+            .onEach { isFirstTimeLaunch ->
+                _isFirstTimeLaunch.emit(isFirstTimeLaunch)
+            }
+            .flowOn(dispatchersProvider.io)
+            .catch { e -> _error.emit(e) }
+            .launchIn(viewModelScope)
     }
 
     fun onFirstTimeLaunch() {

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
@@ -15,10 +15,10 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    dispatchersProvider: DispatchersProvider,
     getModelsUseCase: GetModelsUseCase,
     isFirstTimeLaunchPreferencesUseCase: IsFirstTimeLaunchPreferencesUseCase,
-    updateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase,
+    private val updateFirstTimeLaunchPreferencesUseCase: UpdateFirstTimeLaunchPreferencesUseCase,
+    private val dispatchersProvider: DispatchersProvider,
 ) : BaseViewModel() {
 
     private val _uiModels = MutableStateFlow<List<UiModel>>(emptyList())
@@ -44,9 +44,13 @@ class HomeViewModel @Inject constructor(
                 .first()
 
             _isFirstTimeLaunch.emit(isFirstTimeLaunch)
-            if (isFirstTimeLaunch) {
-                updateFirstTimeLaunchPreferencesUseCase(false)
-            }
+        }
+    }
+
+    fun onFirstTimeLaunch() {
+        launch(dispatchersProvider.io) {
+            updateFirstTimeLaunchPreferencesUseCase(false)
+            _isFirstTimeLaunch.emit(false)
         }
     }
 

--- a/sample-compose/app/src/main/res/values/strings.xml
+++ b/sample-compose/app/src/main/res/values/strings.xml
@@ -11,4 +11,6 @@
     <string name="third_title_bar">Third</string>
     <string name="third_data_title">Data: %s</string>
     <string name="third_edit_menu_title">Edit</string>
+
+    <string name="message_first_time_launch">This is the first time launch</string>
 </resources>

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -106,10 +106,10 @@ class HomeScreenTest : BaseScreenTest() {
 
     private fun initViewModel() {
         viewModel = HomeViewModel(
-            coroutinesRule.testDispatcherProvider,
             mockGetModelsUseCase,
             mockIsFirstTimeLaunchPreferencesUseCase,
-            mockUpdateFirstTimeLaunchPreferencesUseCase
+            mockUpdateFirstTimeLaunchPreferencesUseCase,
+            coroutinesRule.testDispatcherProvider
         )
     }
 }

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -14,8 +14,7 @@ import co.nimblehq.sample.compose.ui.screens.BaseScreenTest
 import co.nimblehq.sample.compose.ui.screens.MainActivity
 import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 import io.kotest.matchers.shouldBe
-import io.mockk.every
-import io.mockk.mockk
+import io.mockk.*
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.*
@@ -54,6 +53,29 @@ class HomeScreenTest : BaseScreenTest() {
             listOf(Model(1), Model(2), Model(3))
         )
         every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(false)
+        coEvery { mockUpdateFirstTimeLaunchPreferencesUseCase(any()) } just Runs
+    }
+
+    @Test
+    fun `When entering the Home screen for the first time, it shows a toast confirming that`() {
+        every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(true)
+
+        initComposable {
+            composeRule.waitForIdle()
+            advanceUntilIdle()
+
+            ShadowToast.showedToast(activity.getString(R.string.message_first_time_launch)) shouldBe true
+        }
+    }
+
+    @Test
+    fun `When entering the Home screen NOT for the first time, it doesn't show the toast confirming that`() {
+        initComposable {
+            composeRule.waitForIdle()
+            advanceUntilIdle()
+
+            ShadowToast.showedToast(activity.getString(R.string.message_first_time_launch)) shouldBe false
+        }
     }
 
     @Test

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
@@ -8,11 +8,9 @@ import co.nimblehq.sample.compose.test.CoroutineTestRule
 import co.nimblehq.sample.compose.ui.AppDestination
 import co.nimblehq.sample.compose.util.DispatchersProvider
 import io.kotest.matchers.shouldBe
-import io.mockk.every
-import io.mockk.mockk
+import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.test.*
 import org.junit.*
 
@@ -34,6 +32,7 @@ class HomeViewModelTest {
     fun setUp() {
         every { mockGetModelsUseCase() } returns flowOf(models)
         every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(false)
+        coEvery { mockUpdateFirstTimeLaunchPreferencesUseCase(any()) } just Runs
 
         initViewModel()
     }
@@ -78,12 +77,23 @@ class HomeViewModelTest {
         }
     }
 
+    @Test
+    fun `When launching the app for the first time, it executes the use case and emits value accordingly`() =
+        runTest {
+            viewModel.onFirstTimeLaunch()
+
+            coVerify(exactly = 1) {
+                mockUpdateFirstTimeLaunchPreferencesUseCase(false)
+            }
+            viewModel.isFirstTimeLaunch.first() shouldBe false
+        }
+
     private fun initViewModel(dispatchers: DispatchersProvider = coroutinesRule.testDispatcherProvider) {
         viewModel = HomeViewModel(
-            dispatchers,
             mockGetModelsUseCase,
             mockIsFirstTimeLaunchPreferencesUseCase,
-            mockUpdateFirstTimeLaunchPreferencesUseCase
+            mockUpdateFirstTimeLaunchPreferencesUseCase,
+            dispatchers
         )
     }
 }

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
@@ -85,6 +85,21 @@ class HomeViewModelTest {
         }
 
     @Test
+    fun `When initializing the ViewModel and isFirstTimeLaunchPreferencesUseCase returns error, it shows the corresponding error`() =
+        runTest {
+            val error = Exception()
+            every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flow { throw error }
+
+            initViewModel(dispatchers = CoroutineTestRule(StandardTestDispatcher()).testDispatcherProvider)
+
+            viewModel.error.test {
+                advanceUntilIdle()
+
+                expectMostRecentItem() shouldBe error
+            }
+        }
+
+    @Test
     fun `When launching the app for the first time, it executes the use case and emits value accordingly`() =
         runTest {
             viewModel.onFirstTimeLaunch()

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
@@ -27,11 +27,12 @@ class HomeViewModelTest {
     private lateinit var viewModel: HomeViewModel
 
     private val models = listOf(Model(1), Model(2), Model(3))
+    private val isFirstTimeLaunch = false
 
     @Before
     fun setUp() {
         every { mockGetModelsUseCase() } returns flowOf(models)
-        every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(false)
+        every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(isFirstTimeLaunch)
         coEvery { mockUpdateFirstTimeLaunchPreferencesUseCase(any()) } just Runs
 
         initViewModel()
@@ -76,6 +77,12 @@ class HomeViewModelTest {
             expectMostRecentItem() shouldBe AppDestination.Second
         }
     }
+
+    @Test
+    fun `When initializing the ViewModel, it emits whether the app is launched for the first time accordingly`() =
+        runTest {
+            viewModel.isFirstTimeLaunch.first() shouldBe isFirstTimeLaunch
+        }
 
     @Test
     fun `When launching the app for the first time, it executes the use case and emits value accordingly`() =


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/419

## What happened 👀

When the app is launched for the first time, we show a toast saying "This is the first time launch". After navigating to the second screen by clicking an item on the list and then navigating back to home, the toast reappears.

Expected behavior: show the toast message only once on the Home screen when the app is launched for the first time.

## Insight 📝

* The `isFirstTimeLaunch` `StateFlow` is being observed from `HomeScreen`. `isFirstTimeLaunch` is updated only once when initializing the VM. So everytime the user navigates back from the second screen, the initial value `true` is observed by `HomeScreen` resulting in the bug.
* Fixed the issue by updating the `SharedPreferences` value as well as `isFirstTimeLaunch` only _after_ the toast is shown on the screen.
* Potential issue: if `UpdateFirstTimeLaunchPreferencesUseCase` runs into an error, `isFirstTimeLaunch` will still be updated with `false` and restarting the app will show the toast again.

## Proof Of Work 📹

https://github.com/nimblehq/android-templates/assets/8093908/7d69388b-da84-4b36-8307-66470e181306


