### PR TITLE
[#479] Fix: Moshi @Json annotation does not work properly on the release build

### DIFF
--- a/sample-compose/app/proguard-rules.pro
+++ b/sample-compose/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Data class
+-keepclassmembers class co.nimblehq.sample.compose.data.request.** { *; }
+-keepclassmembers class co.nimblehq.sample.compose.data.response.** { *; }

--- a/sample-compose/app/src/debug/AndroidManifest.xml
+++ b/sample-compose/app/src/debug/AndroidManifest.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="co.nimblehq.sample.xml">
+    package="co.nimblehq.sample.compose">
 
     <!--For Chucker in debug build only-->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-
-    <application>
-        <activity
-            android:name=".EmptyHiltActivity"
-            android:exported="false" />
-    </application>
 
 </manifest>

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/model/UiModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/model/UiModel.kt
@@ -6,7 +6,11 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class UiModel(
-    val id: String
+    val id: String,
+    val userName: String,
 ) : Parcelable
 
-fun Model.toUiModel() = UiModel(id.toString())
+fun Model.toUiModel() = UiModel(
+    id.toString(),
+    userName.orEmpty(),
+)

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/model/UiModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/model/UiModel.kt
@@ -7,10 +7,10 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class UiModel(
     val id: String,
-    val userName: String,
+    val username: String,
 ) : Parcelable
 
 fun Model.toUiModel() = UiModel(
     id.toString(),
-    userName.orEmpty(),
+    username.orEmpty(),
 )

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreen.kt
@@ -109,7 +109,7 @@ private fun HomeScreenContent(
 private fun HomeScreenPreview() {
     ComposeTheme {
         HomeScreenContent(
-            uiModels = listOf(UiModel("1"), UiModel("2"), UiModel("3")),
+            uiModels = listOf(UiModel("1", "name1"), UiModel("2", "name2"), UiModel("3", "name3")),
             isLoading = false,
             onItemClick = {},
             onItemLongClick = {}

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
@@ -30,12 +30,21 @@ fun Item(
                 onLongClick = { expanded = true }
             )
     ) {
-        Text(
-            modifier = Modifier
-                .padding(dimensions.spacingNormal)
-                .fillMaxWidth(0.8f),
-            text = uiModel.id
-        )
+        Row {
+            Text(
+                modifier = Modifier
+                    .padding(dimensions.spacingNormal)
+                    .weight(1f),
+                text = uiModel.id
+            )
+            Text(
+                modifier = Modifier
+                    .padding(dimensions.spacingNormal)
+                    .weight(2f),
+                text = uiModel.userName
+            )
+        }
+
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false }
@@ -52,7 +61,7 @@ fun Item(
 private fun ItemPreview() {
     ComposeTheme {
         Item(
-            uiModel = UiModel("1"),
+            uiModel = UiModel("1", "name1"),
             onClick = {},
             onLongClick = {}
         )

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
@@ -41,7 +41,7 @@ fun Item(
                 modifier = Modifier
                     .padding(dimensions.spacingNormal)
                     .weight(2f),
-                text = uiModel.userName
+                text = uiModel.username
             )
         }
 

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/ItemList.kt
@@ -33,7 +33,7 @@ fun ItemList(
 private fun ItemListPreview() {
     ComposeTheme {
         ItemList(
-            uiModels = listOf(UiModel("1"), UiModel("2"), UiModel("3")),
+            uiModels = listOf(UiModel("1", "name1"), UiModel("2", "name2"), UiModel("3", "name3")),
             onItemClick = {},
             onItemLongClick = {}
         )

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/third/ThirdScreen.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/third/ThirdScreen.kt
@@ -1,6 +1,8 @@
 package co.nimblehq.sample.compose.ui.screens.third
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -20,7 +22,7 @@ import co.nimblehq.sample.compose.ui.theme.ComposeTheme
 fun ThirdScreen(
     viewModel: ThirdViewModel = hiltViewModel(),
     navigator: (destination: AppDestination) -> Unit,
-    model: UiModel?
+    model: UiModel?,
 ) {
     ThirdScreenContent(data = model)
 }
@@ -50,6 +52,6 @@ fun ThirdScreenContent(data: UiModel?) {
 @Composable
 fun ThirdScreenPreview() {
     ComposeTheme {
-        ThirdScreenContent(data = UiModel("1"))
+        ThirdScreenContent(data = UiModel("1", "name1"))
     }
 }

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/test/MockUtil.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/test/MockUtil.kt
@@ -1,0 +1,21 @@
+package co.nimblehq.sample.compose.test
+
+import co.nimblehq.sample.compose.domain.model.Model
+
+object MockUtil {
+
+    val models = listOf(
+        Model(
+            id = 1,
+            userName = "name1",
+        ),
+        Model(
+            id = 2,
+            userName = "name2",
+        ),
+        Model(
+            id = 3,
+            userName = "name3",
+        ),
+    )
+}

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/test/MockUtil.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/test/MockUtil.kt
@@ -7,15 +7,15 @@ object MockUtil {
     val models = listOf(
         Model(
             id = 1,
-            userName = "name1",
+            username = "name1",
         ),
         Model(
             id = 2,
-            userName = "name2",
+            username = "name2",
         ),
         Model(
             id = 3,
-            userName = "name3",
+            username = "name3",
         ),
     )
 }

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeScreenTest.kt
@@ -7,8 +7,8 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.rule.GrantPermissionRule
 import co.nimblehq.sample.compose.R
-import co.nimblehq.sample.compose.domain.model.Model
 import co.nimblehq.sample.compose.domain.usecase.*
+import co.nimblehq.sample.compose.test.MockUtil
 import co.nimblehq.sample.compose.ui.AppDestination
 import co.nimblehq.sample.compose.ui.screens.BaseScreenTest
 import co.nimblehq.sample.compose.ui.screens.MainActivity
@@ -49,9 +49,7 @@ class HomeScreenTest : BaseScreenTest() {
 
     @Before
     fun setUp() {
-        every { mockGetModelsUseCase() } returns flowOf(
-            listOf(Model(1), Model(2), Model(3))
-        )
+        every { mockGetModelsUseCase() } returns flowOf(MockUtil.models)
         every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(false)
         coEvery { mockUpdateFirstTimeLaunchPreferencesUseCase(any()) } just Runs
     }

--- a/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
+++ b/sample-compose/app/src/test/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModelTest.kt
@@ -1,18 +1,24 @@
 package co.nimblehq.sample.compose.ui.screens.home
 
 import app.cash.turbine.test
-import co.nimblehq.sample.compose.domain.model.Model
-import co.nimblehq.sample.compose.domain.usecase.*
+import co.nimblehq.sample.compose.domain.usecase.GetModelsUseCase
+import co.nimblehq.sample.compose.domain.usecase.IsFirstTimeLaunchPreferencesUseCase
+import co.nimblehq.sample.compose.domain.usecase.UpdateFirstTimeLaunchPreferencesUseCase
 import co.nimblehq.sample.compose.model.toUiModel
 import co.nimblehq.sample.compose.test.CoroutineTestRule
+import co.nimblehq.sample.compose.test.MockUtil
 import co.nimblehq.sample.compose.ui.AppDestination
 import co.nimblehq.sample.compose.util.DispatchersProvider
 import io.kotest.matchers.shouldBe
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.test.*
-import org.junit.*
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
 
 @ExperimentalCoroutinesApi
 class HomeViewModelTest {
@@ -26,12 +32,11 @@ class HomeViewModelTest {
 
     private lateinit var viewModel: HomeViewModel
 
-    private val models = listOf(Model(1), Model(2), Model(3))
     private val isFirstTimeLaunch = false
 
     @Before
     fun setUp() {
-        every { mockGetModelsUseCase() } returns flowOf(models)
+        every { mockGetModelsUseCase() } returns flowOf(MockUtil.models)
         every { mockIsFirstTimeLaunchPreferencesUseCase() } returns flowOf(isFirstTimeLaunch)
         coEvery { mockUpdateFirstTimeLaunchPreferencesUseCase(any()) } just Runs
 
@@ -41,7 +46,7 @@ class HomeViewModelTest {
     @Test
     fun `When loading models successfully, it shows the model list`() = runTest {
         viewModel.uiModels.test {
-            expectMostRecentItem() shouldBe models.map { it.toUiModel() }
+            expectMostRecentItem() shouldBe MockUtil.models.map { it.toUiModel() }
         }
     }
 
@@ -72,7 +77,7 @@ class HomeViewModelTest {
     @Test
     fun `When calling navigate to Second, it navigates to Second screen`() = runTest {
         viewModel.navigator.test {
-            viewModel.navigateToSecond(models[0].toUiModel())
+            viewModel.navigateToSecond(MockUtil.models[0].toUiModel())
 
             expectMostRecentItem() shouldBe AppDestination.Second
         }

--- a/sample-compose/buildSrc/src/main/java/Versions.kt
+++ b/sample-compose/buildSrc/src/main/java/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val BUILD_GRADLE_VERSION = "7.3.0"
+    const val BUILD_GRADLE_VERSION = "7.4.2"
 
     const val ANDROID_COMPILE_SDK_VERSION = 33
     const val ANDROID_MIN_SDK_VERSION = 24

--- a/sample-compose/data/src/main/java/co/nimblehq/sample/compose/data/response/Response.kt
+++ b/sample-compose/data/src/main/java/co/nimblehq/sample/compose/data/response/Response.kt
@@ -4,9 +4,15 @@ import co.nimblehq.sample.compose.domain.model.Model
 import com.squareup.moshi.Json
 
 data class Response(
-    @Json(name = "id") val id: Int?
+    @Json(name = "id")
+    val id: Int?,
+    @Json(name = "username")
+    val userName: String?,
 )
 
-private fun Response.toModel() = Model(id = this.id)
+private fun Response.toModel() = Model(
+    id = this.id,
+    userName = this.userName,
+)
 
 fun List<Response>.toModels() = this.map { it.toModel() }

--- a/sample-compose/data/src/main/java/co/nimblehq/sample/compose/data/response/Response.kt
+++ b/sample-compose/data/src/main/java/co/nimblehq/sample/compose/data/response/Response.kt
@@ -6,13 +6,14 @@ import com.squareup.moshi.Json
 data class Response(
     @Json(name = "id")
     val id: Int?,
+    // A sample to ensure @Json annotation work properly with a differ between field name and JSON key name
     @Json(name = "username")
     val userName: String?,
 )
 
 private fun Response.toModel() = Model(
     id = this.id,
-    userName = this.userName,
+    username = this.userName,
 )
 
 fun List<Response>.toModels() = this.map { it.toModel() }

--- a/sample-compose/data/src/test/java/co/nimblehq/sample/compose/data/repository/RepositoryTest.kt
+++ b/sample-compose/data/src/test/java/co/nimblehq/sample/compose/data/repository/RepositoryTest.kt
@@ -1,8 +1,8 @@
 package co.nimblehq.sample.compose.data.repository
 
-import co.nimblehq.sample.compose.data.response.Response
 import co.nimblehq.sample.compose.data.response.toModels
 import co.nimblehq.sample.compose.data.service.ApiService
+import co.nimblehq.sample.compose.data.test.MockUtil
 import co.nimblehq.sample.compose.domain.repository.Repository
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -20,8 +20,6 @@ class RepositoryTest {
     private lateinit var mockService: ApiService
     private lateinit var repository: Repository
 
-    private val response = Response(id = 1)
-
     @Before
     fun setUp() {
         mockService = mockk()
@@ -30,7 +28,7 @@ class RepositoryTest {
 
     @Test
     fun `When request successful, it returns success`() = runTest {
-        val expected = listOf(response)
+        val expected = MockUtil.responses
         coEvery { mockService.getResponses() } returns expected
 
         repository.getModels().collect {

--- a/sample-compose/data/src/test/java/co/nimblehq/sample/compose/data/test/MockUtil.kt
+++ b/sample-compose/data/src/test/java/co/nimblehq/sample/compose/data/test/MockUtil.kt
@@ -29,4 +29,11 @@ object MockUtil {
     val errorResponse = ErrorResponse(
         message = "message"
     )
+
+    val responses = listOf(
+        co.nimblehq.sample.compose.data.response.Response(
+            id = 1,
+            userName = "name1",
+        )
+    )
 }

--- a/sample-compose/domain/src/main/java/co/nimblehq/sample/compose/domain/model/Model.kt
+++ b/sample-compose/domain/src/main/java/co/nimblehq/sample/compose/domain/model/Model.kt
@@ -2,5 +2,5 @@ package co.nimblehq.sample.compose.domain.model
 
 data class Model(
     val id: Int?,
-    val userName: String?,
+    val username: String?,
 )

--- a/sample-compose/domain/src/main/java/co/nimblehq/sample/compose/domain/model/Model.kt
+++ b/sample-compose/domain/src/main/java/co/nimblehq/sample/compose/domain/model/Model.kt
@@ -1,5 +1,6 @@
 package co.nimblehq.sample.compose.domain.model
 
 data class Model(
-    val id: Int?
+    val id: Int?,
+    val userName: String?,
 )

--- a/sample-compose/domain/src/test/java/co/nimblehq/sample/compose/domain/test/MockUtil.kt
+++ b/sample-compose/domain/src/test/java/co/nimblehq/sample/compose/domain/test/MockUtil.kt
@@ -7,7 +7,7 @@ object MockUtil {
     val models = listOf(
         Model(
             id = 1,
-            userName = "name1",
+            username = "name1",
         )
     )
 }

--- a/sample-compose/domain/src/test/java/co/nimblehq/sample/compose/domain/test/MockUtil.kt
+++ b/sample-compose/domain/src/test/java/co/nimblehq/sample/compose/domain/test/MockUtil.kt
@@ -1,0 +1,13 @@
+package co.nimblehq.sample.compose.domain.test
+
+import co.nimblehq.sample.compose.domain.model.Model
+
+object MockUtil {
+
+    val models = listOf(
+        Model(
+            id = 1,
+            userName = "name1",
+        )
+    )
+}

--- a/sample-compose/domain/src/test/java/co/nimblehq/sample/compose/domain/usecase/GetModelsUseCaseTest.kt
+++ b/sample-compose/domain/src/test/java/co/nimblehq/sample/compose/domain/usecase/GetModelsUseCaseTest.kt
@@ -1,12 +1,15 @@
 package co.nimblehq.sample.compose.domain.usecase
 
-import co.nimblehq.sample.compose.domain.model.Model
 import co.nimblehq.sample.compose.domain.repository.Repository
+import co.nimblehq.sample.compose.domain.test.MockUtil
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -17,8 +20,6 @@ class GetModelsUseCaseTest {
     private lateinit var mockRepository: Repository
     private lateinit var getModelsUseCase: GetModelsUseCase
 
-    private val model = Model(id = 1)
-
     @Before
     fun setUp() {
         mockRepository = mockk()
@@ -27,7 +28,7 @@ class GetModelsUseCaseTest {
 
     @Test
     fun `When request successful, it returns success`() = runTest {
-        val expected = listOf(model)
+        val expected = MockUtil.models
         every { mockRepository.getModels() } returns flowOf(expected)
 
         getModelsUseCase().collect {

--- a/sample-compose/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-compose/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jun 28 08:46:12 ICT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/sample-xml/app/proguard-rules.pro
+++ b/sample-xml/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Data class
+-keepclassmembers class co.nimblehq.sample.xml.data.request.** { *; }
+-keepclassmembers class co.nimblehq.sample.xml.data.response.** { *; }

--- a/sample-xml/buildSrc/src/main/java/Versions.kt
+++ b/sample-xml/buildSrc/src/main/java/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val BUILD_GRADLE_VERSION = "7.3.0"
+    const val BUILD_GRADLE_VERSION = "7.4.2"
 
     const val ANDROID_COMPILE_SDK_VERSION = 33
     const val ANDROID_MIN_SDK_VERSION = 24

--- a/sample-xml/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-xml/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jun 28 08:46:12 ICT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/template-compose/app/proguard-rules.pro
+++ b/template-compose/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Data class
+-keepclassmembers class co.nimblehq.template.compose.data.request.** { *; }
+-keepclassmembers class co.nimblehq.template.compose.data.response.** { *; }

--- a/template-compose/app/src/debug/AndroidManifest.xml
+++ b/template-compose/app/src/debug/AndroidManifest.xml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="co.nimblehq.sample.xml">
+    package="co.nimblehq.template.compose">
 
     <!--For Chucker in debug build only-->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-
-    <application>
-        <activity
-            android:name=".EmptyHiltActivity"
-            android:exported="false" />
-    </application>
 
 </manifest>

--- a/template-compose/app/src/test/java/co/nimblehq/template/compose/test/MockUtil.kt
+++ b/template-compose/app/src/test/java/co/nimblehq/template/compose/test/MockUtil.kt
@@ -1,0 +1,12 @@
+package co.nimblehq.template.compose.test
+
+import co.nimblehq.template.compose.domain.model.Model
+
+object MockUtil {
+
+    val models = listOf(
+        Model(id = 1),
+        Model(id = 2),
+        Model(id = 3),
+    )
+}

--- a/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
+++ b/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeScreenTest.kt
@@ -5,8 +5,8 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import co.nimblehq.template.compose.R
-import co.nimblehq.template.compose.domain.model.Model
 import co.nimblehq.template.compose.domain.usecase.UseCase
+import co.nimblehq.template.compose.test.MockUtil
 import co.nimblehq.template.compose.ui.AppDestination
 import co.nimblehq.template.compose.ui.screens.BaseScreenTest
 import co.nimblehq.template.compose.ui.screens.MainActivity
@@ -35,9 +35,7 @@ class HomeScreenTest : BaseScreenTest() {
 
     @Before
     fun setUp() {
-        every { mockUseCase() } returns flowOf(
-            listOf(Model(1), Model(2), Model(3))
-        )
+        every { mockUseCase() } returns flowOf(MockUtil.models)
     }
 
     @Test

--- a/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModelTest.kt
+++ b/template-compose/app/src/test/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModelTest.kt
@@ -1,10 +1,10 @@
 package co.nimblehq.template.compose.ui.screens.home
 
 import app.cash.turbine.test
-import co.nimblehq.template.compose.domain.model.Model
 import co.nimblehq.template.compose.domain.usecase.UseCase
 import co.nimblehq.template.compose.model.toUiModel
 import co.nimblehq.template.compose.test.CoroutineTestRule
+import co.nimblehq.template.compose.test.MockUtil
 import co.nimblehq.template.compose.util.DispatchersProvider
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -25,11 +25,9 @@ class HomeViewModelTest {
 
     private lateinit var viewModel: HomeViewModel
 
-    private val models = listOf(Model(1), Model(2), Model(3))
-
     @Before
     fun setUp() {
-        every { mockUseCase() } returns flowOf(models)
+        every { mockUseCase() } returns flowOf(MockUtil.models)
 
         initViewModel()
     }
@@ -37,7 +35,7 @@ class HomeViewModelTest {
     @Test
     fun `When loading models successfully, it shows the model list`() = runTest {
         viewModel.uiModels.test {
-            expectMostRecentItem() shouldBe models.map { it.toUiModel() }
+            expectMostRecentItem() shouldBe MockUtil.models.map { it.toUiModel() }
         }
     }
 

--- a/template-compose/buildSrc/src/main/java/Versions.kt
+++ b/template-compose/buildSrc/src/main/java/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val BUILD_GRADLE_VERSION = "7.3.0"
+    const val BUILD_GRADLE_VERSION = "7.4.2"
 
     const val ANDROID_COMPILE_SDK_VERSION = 33
     const val ANDROID_MIN_SDK_VERSION = 24

--- a/template-compose/data/src/test/java/co/nimblehq/template/compose/data/repository/RepositoryTest.kt
+++ b/template-compose/data/src/test/java/co/nimblehq/template/compose/data/repository/RepositoryTest.kt
@@ -1,8 +1,8 @@
 package co.nimblehq.template.compose.data.repository
 
-import co.nimblehq.template.compose.data.response.Response
 import co.nimblehq.template.compose.data.response.toModels
 import co.nimblehq.template.compose.data.service.ApiService
+import co.nimblehq.template.compose.data.test.MockUtil
 import co.nimblehq.template.compose.domain.repository.Repository
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -20,8 +20,6 @@ class RepositoryTest {
     private lateinit var mockService: ApiService
     private lateinit var repository: Repository
 
-    private val response = Response(id = 1)
-
     @Before
     fun setUp() {
         mockService = mockk()
@@ -30,7 +28,7 @@ class RepositoryTest {
 
     @Test
     fun `When request successful, it returns success`() = runTest {
-        val expected = listOf(response)
+        val expected = MockUtil.responses
         coEvery { mockService.getResponses() } returns expected
 
         repository.getModels().collect {

--- a/template-compose/data/src/test/java/co/nimblehq/template/compose/data/test/MockUtil.kt
+++ b/template-compose/data/src/test/java/co/nimblehq/template/compose/data/test/MockUtil.kt
@@ -29,4 +29,8 @@ object MockUtil {
     val errorResponse = ErrorResponse(
         message = "message"
     )
+
+    val responses = listOf(
+        co.nimblehq.template.compose.data.response.Response(id = 1)
+    )
 }

--- a/template-compose/domain/src/test/java/co/nimblehq/template/compose/domain/test/MockUtil.kt
+++ b/template-compose/domain/src/test/java/co/nimblehq/template/compose/domain/test/MockUtil.kt
@@ -1,0 +1,10 @@
+package co.nimblehq.template.compose.domain.test
+
+import co.nimblehq.template.compose.domain.model.Model
+
+object MockUtil {
+
+    val models = listOf(
+        Model(id = 1)
+    )
+}

--- a/template-compose/domain/src/test/java/co/nimblehq/template/compose/domain/usecase/UseCaseTest.kt
+++ b/template-compose/domain/src/test/java/co/nimblehq/template/compose/domain/usecase/UseCaseTest.kt
@@ -1,9 +1,10 @@
 package co.nimblehq.template.compose.domain.usecase
 
-import co.nimblehq.template.compose.domain.model.Model
 import co.nimblehq.template.compose.domain.repository.Repository
+import co.nimblehq.template.compose.domain.test.MockUtil
 import io.kotest.matchers.shouldBe
-import io.mockk.*
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.test.runTest
@@ -16,8 +17,6 @@ class UseCaseTest {
     private lateinit var mockRepository: Repository
     private lateinit var useCase: UseCase
 
-    private val model = Model(id = 1)
-
     @Before
     fun setUp() {
         mockRepository = mockk()
@@ -26,7 +25,7 @@ class UseCaseTest {
 
     @Test
     fun `When request successful, it returns success`() = runTest {
-        val expected = listOf(model)
+        val expected = MockUtil.models
         every { mockRepository.getModels() } returns flowOf(expected)
 
         useCase().collect {

--- a/template-compose/gradle/wrapper/gradle-wrapper.properties
+++ b/template-compose/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 11 23:57:05 ICT 2022
+#Wed Jun 28 08:46:12 ICT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/template-xml/app/proguard-rules.pro
+++ b/template-xml/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Data class
+-keepclassmembers class co.nimblehq.template.xml.data.request.** { *; }
+-keepclassmembers class co.nimblehq.template.xml.data.response.** { *; }

--- a/template-xml/app/src/debug/AndroidManifest.xml
+++ b/template-xml/app/src/debug/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="co.nimblehq.template.xml">
 
+    <!--For Chucker in debug build only-->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application>
         <activity
             android:name=".EmptyHiltActivity"

--- a/template-xml/buildSrc/src/main/java/Versions.kt
+++ b/template-xml/buildSrc/src/main/java/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val BUILD_GRADLE_VERSION = "7.3.0"
+    const val BUILD_GRADLE_VERSION = "7.4.2"
 
     const val ANDROID_COMPILE_SDK_VERSION = 33
     const val ANDROID_MIN_SDK_VERSION = 24

--- a/template-xml/gradle/wrapper/gradle-wrapper.properties
+++ b/template-xml/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 11 23:57:05 ICT 2022
+#Wed Jun 28 08:46:12 ICT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/479

## What happened 👀

- Fix: keep all data models in proguard.
- Fix: @JSON does not work on the release build by `upgrading AGP to 7.4.2`.

## Insight 📝

- The Moshi `@Json annotation does not work on the release build` (while working with debug build) 👉 I did some research on this:
  - [Updating proguard rules does not work](https://stackoverflow.com/questions/57034937/moshi-kotlinjsonadapterfactory-cannot-parse-json-after-enabled-minify) ❌ 
  - [Adding `@Keep` or `@JsonClass(generateAdapter = false)` annotations does not work](https://stackoverflow.com/questions/60166217/moshi-json-annotation-does-not-work-with-proguard) ❌ 
  - [Switching to `@field:Json` works on the release build, but does not work with debug build](https://github.com/square/moshi/issues/446#issuecomment-367732968) ❌ 
  - [This might be a bug in Android Gradle Plugin](https://github.com/square/moshi/issues/1458#issuecomment-1001718894), [upgrading to AGP 7.4.2 solves the issue](https://stackoverflow.com/questions/70315232/data-class-metadata-is-removed-with-proguard-r8-for-kotlin-1-6-0/70331139#70331139) ✅ 

- Upgrading to AGP 7.4.2 will lead to this Lint issue https://github.com/bumptech/glide/issues/4940 (https://github.com/nimblehq/android-templates/actions/runs/5396819037/jobs/9800872801)
	```
	/home/vsts/work/1/s/app/src/main/AndroidManifest.xml: Error: When targeting Android 13 or higher, posting a permission requires holding the POST_NOTIFICATIONS permission (usage from com.chuckerteam.chucker.internal.support.NotificationHelper) [NotificationPermission]
	  
	     Explanation for issues of type "NotificationPermission":
	     When targeting Android 13 and higher, posting permissions requires holding
	     the runtime permission android.permission.POST_NOTIFICATIONS.
	```
	
	👉 To fix this, add a new debug `AndroidManifest.xml` with a additional `<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />` ✅ 


- Another issue: We must keep them from code obfuscation by proguard rules.

## Proof Of Work 📹


| None of fixes | Add proguard rules for models | Upgrade AGP to 7.4.2 |
|--------|--------|--------|
| ![Screenshot_20230628-090526](https://github.com/nimblehq/android-templates/assets/16315358/0679081e-46a4-4f5f-8f0e-0745fb120676) | ![Screenshot_20230628-090814](https://github.com/nimblehq/android-templates/assets/16315358/3eef6612-4f08-49f1-8c9b-6faa3e518450) | ![Screenshot_20230628-090031](https://github.com/nimblehq/android-templates/assets/16315358/53309184-261c-4f01-841d-13a7b56b9b07) | 



