### PR TITLE
[#485] Fix repositories import syntax to be in Kotlin format for maven Jitpack

### DIFF
--- a/RxJavaTemplate[DEPRECATED]/build.gradle.kts
+++ b/RxJavaTemplate[DEPRECATED]/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        maven(url = "https://jitpack.io")
+        maven { url = uri("https://www.jitpack.io") }
         mavenCentral()
     }
 }

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        maven(url = "https://jitpack.io")
+        maven { url = uri("https://www.jitpack.io") }
         mavenCentral()
     }
 }

--- a/sample-xml/build.gradle.kts
+++ b/sample-xml/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        maven(url = "https://jitpack.io")
+        maven { url = uri("https://www.jitpack.io") }
         mavenCentral()
     }
 }

--- a/template-compose/build.gradle.kts
+++ b/template-compose/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        maven(url = "https://jitpack.io")
+        maven { url = uri("https://www.jitpack.io") }
         mavenCentral()
     }
 }

--- a/template-xml/build.gradle.kts
+++ b/template-xml/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        maven(url = "https://jitpack.io")
+        maven { url = uri("https://www.jitpack.io") }
         mavenCentral()
     }
 }


### PR DESCRIPTION
- Close https://github.com/nimblehq/android-templates/issues/485

## What happened 👀

- Update the maven import to be in Kotlin format

## Insight 📝

Ref: https://stackoverflow.com/a/66926254/11393626

## Proof Of Work 📹

The CI should be successful.
