### PR TITLE
[#485] Update import libraries from mavenCentral if possible

### DIFF
--- a/RxJavaTemplate[DEPRECATED]/build.gradle.kts
+++ b/RxJavaTemplate[DEPRECATED]/build.gradle.kts
@@ -21,8 +21,8 @@ plugins {
 allprojects {
     repositories {
         google()
-        maven { url = uri("https://www.jitpack.io") }
         mavenCentral()
+        maven { url = uri("https://www.jitpack.io") }
     }
 }
 

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -20,8 +20,8 @@ plugins {
 allprojects {
     repositories {
         google()
-        maven { url = uri("https://www.jitpack.io") }
         mavenCentral()
+        maven { url = uri("https://www.jitpack.io") }
     }
 }
 

--- a/sample-xml/build.gradle.kts
+++ b/sample-xml/build.gradle.kts
@@ -21,8 +21,8 @@ plugins {
 allprojects {
     repositories {
         google()
-        maven { url = uri("https://www.jitpack.io") }
         mavenCentral()
+        maven { url = uri("https://www.jitpack.io") }
     }
 }
 

--- a/template-compose/build.gradle.kts
+++ b/template-compose/build.gradle.kts
@@ -20,8 +20,8 @@ plugins {
 allprojects {
     repositories {
         google()
-        maven { url = uri("https://www.jitpack.io") }
         mavenCentral()
+        maven { url = uri("https://www.jitpack.io") }
     }
 }
 

--- a/template-xml/build.gradle.kts
+++ b/template-xml/build.gradle.kts
@@ -21,8 +21,8 @@ plugins {
 allprojects {
     repositories {
         google()
-        maven { url = uri("https://www.jitpack.io") }
         mavenCentral()
+        maven { url = uri("https://www.jitpack.io") }
     }
 }
 


### PR DESCRIPTION
- Closes https://github.com/nimblehq/android-templates/issues/485

## What happened 👀

- Update import libraries from MavenCentral at a higher priority than Jitpack.

## Insight 📝

As Chucker recommended to be imported from MavenCentral instead Jitpack, so we should follow the instruction.

## Proof Of Work 📹

The CI should be all green.