### PR TITLE
WIP - [#494] Replace danger-ruby with danger-kotlin

### DIFF
--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -69,30 +69,7 @@ jobs:
         working-directory: ./template-compose
         run: ./gradlew koverMergedXmlReport
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
-
-      - name: Cache gems
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-
-      - name: Install Bundle and check environment versions
-        run: |
-          echo 'Install Bundle'
-          bundle config path vendor/bundle
-          bundle install
-          echo 'Check environment setup versions'
-          ruby --version
-          gem --version
-          bundler --version
-
       - name: Run Danger
+        uses: danger/kotlin@1.2.0
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bundle exec danger

--- a/Dangerfile.df.kts
+++ b/Dangerfile.df.kts
@@ -1,0 +1,20 @@
+import systems.danger.kotlin.*
+
+danger(args) {
+    onGitHub {
+        // Make it more obvious that a PR is a work in progress and shouldn't be merged yet
+        if (pullRequest.title.contains("WIP", false)) {
+            warn("PR is classed as Work in Progress")
+        }
+
+        // Warn when there is a big PR
+        if ((pullRequest.additions ?: 0) - (pullRequest.deletions ?: 0) > 500) {
+            warn("Big PR")
+        }
+
+        // Warn to encourage a PR description
+        if (pullRequest.body?.isBlank() == true) {
+            warn("Please provide a summary in the PR description to make it easier to review")
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/494

## What happened 👀

- [ ] Replace `danger-ruby` with `danger-kotlin` on templates' GitHub Actions workflow
- [ ] Replace `danger-ruby` with `danger-kotlin` on generated project's GitHub Actions workflow

## Insight 📝

N/A

## Proof Of Work 📹

Will update
