### PR TITLE
[#496] Distribute app without Firebase integration

### DIFF
--- a/.cicdtemplate/.codemagic/codemagic.yaml
+++ b/.cicdtemplate/.codemagic/codemagic.yaml
@@ -10,13 +10,6 @@ definitions:
       cache_paths:
         - $HOME/.gradle/caches
   scripts:
-    - &set_up_google_services_files_from_environment_variables
-      name: Set up google-services.json files
-      script: |
-        mkdir -p app/src/production
-        echo $GOOGLE_SERVICES_JSON > app/src/production/google-services.json
-        mkdir -p app/src/staging
-        echo $GOOGLE_SERVICES_JSON_STAGING > app/src/staging/google-services.json
     - &detekt
       name: Run detekt
       script: ./gradlew detekt
@@ -47,7 +40,6 @@ workflows:
           include: false
       cancel_previous_builds: true
     scripts:
-      - *set_up_google_services_files_from_environment_variables
       - *detekt
       - *unit_test
     artifacts:
@@ -62,7 +54,6 @@ workflows:
       branch_patterns:
         - pattern: develop
     scripts:
-      - *set_up_google_services_files_from_environment_variables
       - *detekt
       - *unit_test
       - name: Build APK for staging
@@ -89,7 +80,6 @@ workflows:
       branch_patterns:
         - pattern: main
     scripts:
-      - *set_up_google_services_files_from_environment_variables
       - *detekt
       - *unit_test
       - name: Build APK for production

--- a/.cicdtemplate/.github/workflows/deploy_staging_and_production_to_firebase_app_distribution.yml
+++ b/.cicdtemplate/.github/workflows/deploy_staging_and_production_to_firebase_app_distribution.yml
@@ -38,16 +38,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up google-services.json files
-        env:
-          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-          GOOGLE_SERVICES_JSON_STAGING: ${{ secrets.GOOGLE_SERVICES_JSON_STAGING }}
-        run: |
-          mkdir -p app/src/production
-          echo $GOOGLE_SERVICES_JSON > app/src/production/google-services.json
-          mkdir -p app/src/staging
-          echo $GOOGLE_SERVICES_JSON_STAGING > app/src/staging/google-services.json
-
       - name: Run Detekt
         run: ./gradlew detekt
 

--- a/.cicdtemplate/.github/workflows/review_pull_request.yml
+++ b/.cicdtemplate/.github/workflows/review_pull_request.yml
@@ -30,16 +30,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up google-services.json
-        env:
-          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-          GOOGLE_SERVICES_JSON_STAGING: ${{ secrets.GOOGLE_SERVICES_JSON_STAGING }}
-        run: |
-          mkdir -p app/src/production
-          echo $GOOGLE_SERVICES_JSON > app/src/production/google-services.json
-          mkdir -p app/src/staging
-          echo $GOOGLE_SERVICES_JSON_STAGING > app/src/staging/google-services.json
-
       - name: Run Detekt
         run: ./gradlew detekt
 

--- a/.cicdtemplate/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.cicdtemplate/.github/workflows/run_detekt_and_unit_tests.yml
@@ -41,13 +41,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set up google-services.json
-        env:
-          GOOGLE_SERVICES_JSON_STAGING: ${{ secrets.GOOGLE_SERVICES_JSON_STAGING }}
-        run: |
-          mkdir -p app/src/staging
-          echo $GOOGLE_SERVICES_JSON_STAGING > app/src/staging/google-services.json
-
       - name: Run Detekt
         run: ./gradlew detekt
 

--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -47,16 +47,6 @@ jobs:
 
       # template-compose
 
-      - name: Set up google-services.json on template-compose
-        env:
-          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-          GOOGLE_SERVICES_JSON_STAGING: ${{ secrets.GOOGLE_SERVICES_JSON_STAGING }}
-        run: |
-          mkdir -p template-compose/app/src/production
-          echo $GOOGLE_SERVICES_JSON > template-compose/app/src/production/google-services.json
-          mkdir -p template-compose/app/src/staging
-          echo $GOOGLE_SERVICES_JSON_STAGING > template-compose/app/src/staging/google-services.json
-
       - name: Run Detekt on template-compose
         working-directory: ./template-compose
         run: ./gradlew detekt

--- a/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.github/workflows/run_detekt_and_unit_tests.yml
@@ -7,7 +7,6 @@ jobs:
     name: Run Detekt and unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: template-compose
     steps:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -52,13 +51,6 @@ jobs:
           path: template-xml/build/reports/kover/merged/
 
       # template-compose
-
-      - name: Set up google-services.json on template-compose
-        env:
-          GOOGLE_SERVICES_JSON_STAGING: ${{ secrets.GOOGLE_SERVICES_JSON_STAGING }}
-        run: |
-          mkdir -p template-compose/app/src/staging
-          echo $GOOGLE_SERVICES_JSON_STAGING > template-compose/app/src/staging/google-services.json
 
       - name: Run Detekt on template-compose
         working-directory: ./template-compose

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -10,13 +10,6 @@ definitions:
       cache_paths:
         - $HOME/.gradle/caches
   scripts:
-    - &set_up_google_services_files_from_environment_variables
-      name: Set up google-services.json on template-compose
-      script: |
-        mkdir -p template-compose/app/src/production
-        echo $GOOGLE_SERVICES_JSON > template-compose/app/src/production/google-services.json
-        mkdir -p template-compose/app/src/staging
-        echo $GOOGLE_SERVICES_JSON_STAGING > template-compose/app/src/staging/google-services.json
     - &detekt_on_template_compose
       name: Run detekt on template-compose
       working_directory: ./template-compose
@@ -58,7 +51,6 @@ workflows:
           include: false
       cancel_previous_builds: true
     scripts:
-      - *set_up_google_services_files_from_environment_variables
       - *detekt_on_template_compose
       - *unit_test_on_template_compose
     artifacts:
@@ -95,9 +87,8 @@ workflows:
       events:
         - push
       branch_patterns:
-        - pattern: develop
+        - pattern: chore/poc-distribute-app-without-firebase-integration
     scripts:
-      - *set_up_google_services_files_from_environment_variables
       - *detekt_on_template_compose
       - *unit_test_on_template_compose
       - name: Build APK for staging
@@ -125,7 +116,6 @@ workflows:
       branch_patterns:
         - pattern: main
     scripts:
-      - *set_up_google_services_files_from_environment_variables
       - *detekt_on_template_compose
       - *unit_test_on_template_compose
       - name: Build APK for production

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -87,7 +87,7 @@ workflows:
       events:
         - push
       branch_patterns:
-        - pattern: chore/poc-distribute-app-without-firebase-integration
+        - pattern: develop
     scripts:
       - *detekt_on_template_compose
       - *unit_test_on_template_compose

--- a/template-compose/app/build.gradle.kts
+++ b/template-compose/app/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
     id("com.android.application")
 
-    id("com.google.gms.google-services")
-
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
@@ -141,8 +139,6 @@ dependencies {
     implementation("androidx.compose.material:material")
 
     implementation("androidx.datastore:datastore-preferences:${Versions.ANDROIDX_DATASTORE_PREFERENCES_VERSION}")
-
-    implementation(platform("com.google.firebase:firebase-bom:${Versions.FIREBASE_BOM_VERSION}"))
 
     implementation("androidx.navigation:navigation-compose:${Versions.COMPOSE_NAVIGATION_VERSION}")
     implementation("com.google.accompanist:accompanist-permissions:${Versions.ACCOMPANIST_PERMISSIONS_VERSION}")

--- a/template-compose/build.gradle.kts
+++ b/template-compose/build.gradle.kts
@@ -9,7 +9,6 @@ buildscript {
         classpath("com.android.tools.build:gradle:${Versions.BUILD_GRADLE_VERSION}")
         classpath("com.google.dagger:hilt-android-gradle-plugin:${Versions.HILT_VERSION}")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.KOTLIN_VERSION}")
-        classpath("com.google.gms:google-services:${Versions.GOOGLE_SERVICES_VERSION}")
     }
 }
 

--- a/template-compose/buildSrc/src/main/java/Versions.kt
+++ b/template-compose/buildSrc/src/main/java/Versions.kt
@@ -21,9 +21,6 @@ object Versions {
     const val COMPOSE_COMPILER_VERSION = "1.4.7"
     const val COMPOSE_NAVIGATION_VERSION = "2.5.3"
 
-    const val FIREBASE_BOM_VERSION = "32.1.1"
-    const val GOOGLE_SERVICES_VERSION = "4.3.15"
-
     const val HILT_VERSION = "2.44"
     const val HILT_NAVIGATION_COMPOSE_VERSION = "1.0.0"
 


### PR DESCRIPTION
- Close https://github.com/nimblehq/android-templates/issues/496

## What happened 👀

Remove Firebase integration from project

## Insight 📝

- Codemagic can distribute the app to Firebase App Distribution without integrating the Firebase to the project.
- After merging this PR, the `google-services.json` in Github Secrets will be deleted.

Big thanks to @luongvo for noticing this and the POC branch. 🙇🏻‍♀️ 

## Proof Of Work 📹

Github Action to deploy on Firebase result:

https://github.com/nimblehq/android-templates/actions/runs/5712267786/job/15475425029

Codemagic to deploy on Firebase result:

![Screenshot 2566-08-02 at 4 54 16 PM](https://github.com/nimblehq/android-templates/assets/12026942/ff67b46a-ef78-46ad-be94-dc4b597c8add)

