### PR TITLE
[#423] Clean up warnings when generating a new project

### DIFF
--- a/template-compose/domain/src/main/java/co/nimblehq/template/compose/domain/repositories/AppPreferencesRepository.kt
+++ b/template-compose/domain/src/main/java/co/nimblehq/template/compose/domain/repositories/AppPreferencesRepository.kt
@@ -6,5 +6,5 @@ interface AppPreferencesRepository {
 
     fun getAppPreference(): Flow<Boolean>
 
-    suspend fun updateAppPreference(appPreferencesValue: Boolean)
+    suspend fun updateAppPreference(appPreferenceValue: Boolean)
 }

--- a/template-xml/app/build.gradle.kts
+++ b/template-xml/app/build.gradle.kts
@@ -13,6 +13,8 @@ plugins {
 val keystoreProperties = rootDir.loadGradleProperties("signing.properties")
 
 android {
+    namespace = "co.nimblehq.template.xml"
+
     signingConfigs {
         create(BuildType.RELEASE) {
             // Remember to edit signing.properties to have the correct info for release build.

--- a/template-xml/app/src/debug/AndroidManifest.xml
+++ b/template-xml/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="co.nimblehq.template.xml">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!--For Chucker in debug build only-->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/template-xml/app/src/main/AndroidManifest.xml
+++ b/template-xml/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="co.nimblehq.template.xml">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/template-xml/data/build.gradle.kts
+++ b/template-xml/data/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+    namespace = "co.nimblehq.template.xml.data"
     compileSdk = Versions.ANDROID_COMPILE_SDK_VERSION
     defaultConfig {
         minSdk = Versions.ANDROID_MIN_SDK_VERSION

--- a/template-xml/data/src/main/AndroidManifest.xml
+++ b/template-xml/data/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="co.nimblehq.template.xml.data" />
+<manifest />


### PR DESCRIPTION
closes https://github.com/nimblehq/android-templates/issues/423

## What happened 👀

- Moved namespace declarations from `AndroidManifest.xml` files to `build.gradle` files
- Fixed mismatched parameter name

## Insight 📝

We still receive the following warning when building
```
> Task :buildSrc:jar
:jar: No valid plugin descriptors were found in META-INF/gradle-plugins
```
It seems to have been [fixed](https://github.com/gradle/gradle/issues/25795) in Gradle 8.3, but as the current stable Android Gradle plugin is on `8.1.2`, we will still receive this warning for now 👀 

## Proof Of Work 📹

[Verify newproject script log](https://github.com/nimblehq/android-templates/actions/runs/6417405922/job/17423068693?pr=507#step:8:1)
