### PR TITLE
[#502] Remove Bump version XML step from Bump version workflow

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -22,10 +22,6 @@ jobs:
         run: |
           perl -i -pe 's/^(templateScriptVersion=(.*))$/"templateScriptVersion=${{ github.event.inputs.newVersion }}"/e' version.properties
 
-      - name: Bump version XML
-        run: |
-          perl -i -pe 's/ANDROID_VERSION_NAME =(.*)$/ANDROID_VERSION_NAME = "${{ github.event.inputs.newVersion }}"/g' sample-xml/buildSrc/src/main/java/Versions.kt
-
       - name: Bump version Compose
         run: |
           perl -i -pe 's/ANDROID_VERSION_NAME =(.*)$/ANDROID_VERSION_NAME = "${{ github.event.inputs.newVersion }}"/g' sample-compose/buildSrc/src/main/java/Versions.kt


### PR DESCRIPTION
closes #502 

## What happened 👀

- Removed the `Bump version XML` from `bump_version` workflow

## Insight 📝

The XML template is being deprecated so we should no longer bump the version on new iterations 🙏🏻 

## Proof Of Work 📹

[Pull Request](https://github.com/nimblehq/android-templates/pull/526)

[Workflow run](https://github.com/nimblehq/android-templates/actions/runs/6416836897)

![image](https://github.com/nimblehq/android-templates/assets/53168251/424c158f-c29a-4bf1-bcb5-df956385a595)

