### PR TITLE
[#548] Prepare initial setup for deep-link

### DIFF
--- a/sample-compose/app/src/main/AndroidManifest.xml
+++ b/sample-compose/app/src/main/AndroidManifest.xml
@@ -26,6 +26,25 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="android.nimblehq.co" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="android" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppDestination.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppDestination.kt
@@ -1,8 +1,10 @@
 package co.nimblehq.sample.compose.ui
 
 import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavDeepLink
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
+import androidx.navigation.navDeepLink
 import co.nimblehq.sample.compose.model.UiModel
 
 const val KeyId = "id"
@@ -12,6 +14,15 @@ const val KeyResultOk = "keyResultOk"
 sealed class AppDestination(val route: String = "") {
 
     open val arguments: List<NamedNavArgument> = emptyList()
+
+    open val deepLinks: List<NavDeepLink> = listOf(
+        navDeepLink {
+            uriPattern = "https://android.nimblehq.co/$route"
+        },
+        navDeepLink {
+            uriPattern = "android://$route"
+        }
+    )
 
     open var destination: String = route
 

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppDestination.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppDestination.kt
@@ -1,10 +1,8 @@
 package co.nimblehq.sample.compose.ui
 
 import androidx.navigation.NamedNavArgument
-import androidx.navigation.NavDeepLink
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
-import androidx.navigation.navDeepLink
 import co.nimblehq.sample.compose.model.UiModel
 
 const val KeyId = "id"
@@ -15,13 +13,9 @@ sealed class AppDestination(val route: String = "") {
 
     open val arguments: List<NamedNavArgument> = emptyList()
 
-    open val deepLinks: List<NavDeepLink> = listOf(
-        navDeepLink {
-            uriPattern = "https://android.nimblehq.co/$route"
-        },
-        navDeepLink {
-            uriPattern = "android://$route"
-        }
+    open val deepLinks: List<String> = listOf(
+        "https://android.nimblehq.co/$route",
+        "android://$route",
     )
 
     open var destination: String = route

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavGraph.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavGraph.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import co.nimblehq.sample.compose.ui.screens.main.mainNavGraph
 
 @Composable
@@ -28,7 +29,11 @@ fun NavGraphBuilder.composable(
     composable(
         route = destination.route,
         arguments = destination.arguments,
-        deepLinks = destination.deepLinks,
+        deepLinks = destination.deepLinks.map {
+            navDeepLink {
+                uriPattern = it
+            }
+        },
         content = content
     )
 }

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavGraph.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/AppNavGraph.kt
@@ -2,7 +2,6 @@ package co.nimblehq.sample.compose.ui
 
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavDeepLink
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -24,13 +23,12 @@ fun AppNavGraph(
 
 fun NavGraphBuilder.composable(
     destination: AppDestination,
-    deepLinks: List<NavDeepLink> = emptyList(),
     content: @Composable (NavBackStackEntry) -> Unit,
 ) {
     composable(
         route = destination.route,
         arguments = destination.arguments,
-        deepLinks = deepLinks,
+        deepLinks = destination.deepLinks,
         content = content
     )
 }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/AppDestination.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/AppDestination.kt
@@ -1,10 +1,13 @@
 package co.nimblehq.template.compose.ui
 
 import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavDeepLink
 
 sealed class AppDestination(val route: String = "") {
 
     open val arguments: List<NamedNavArgument> = emptyList()
+
+    open val deepLinks: List<NavDeepLink> = emptyList()
 
     open var destination: String = route
 

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/AppDestination.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/AppDestination.kt
@@ -1,13 +1,12 @@
 package co.nimblehq.template.compose.ui
 
 import androidx.navigation.NamedNavArgument
-import androidx.navigation.NavDeepLink
 
 sealed class AppDestination(val route: String = "") {
 
     open val arguments: List<NamedNavArgument> = emptyList()
 
-    open val deepLinks: List<NavDeepLink> = emptyList()
+    open val deepLinks: List<String> = emptyList()
 
     open var destination: String = route
 

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/AppNavGraph.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/AppNavGraph.kt
@@ -21,13 +21,12 @@ fun AppNavGraph(
 
 fun NavGraphBuilder.composable(
     destination: AppDestination,
-    deepLinks: List<NavDeepLink> = emptyList(),
     content: @Composable (NavBackStackEntry) -> Unit,
 ) {
     composable(
         route = destination.route,
         arguments = destination.arguments,
-        deepLinks = deepLinks,
+        deepLinks = destination.deepLinks,
         content = content
     )
 }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/AppNavGraph.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/AppNavGraph.kt
@@ -26,7 +26,11 @@ fun NavGraphBuilder.composable(
     composable(
         route = destination.route,
         arguments = destination.arguments,
-        deepLinks = destination.deepLinks,
+        deepLinks = destination.deepLinks.map {
+            navDeepLink {
+                uriPattern = it
+            }
+        },
         content = content
     )
 }


### PR DESCRIPTION
Closes https://github.com/nimblehq/android-templates/issues/548

## What happened 👀

- Define a new `deeplinks` attribute in AppDestination to config deeplink.
- Add a deeplink sample with 
  - web links `https://android.nimblehq.co/`
  - custom scheme links `android://`

## Insight 📝

- Follow this simple guide https://developer.android.com/jetpack/compose/navigation#deeplinks
- To set up app links, follow https://developer.android.com/studio/write/app-link-indexing. We must request to upload the generated `assetlinks.json` to the host, e.g., https://android.nimblehq.co/.well-known/assetlinks.json.
- Defining `NavDeepLink` with Uri (Android resources) in `AppDestination` caused the unit tests to fail. We must move NavDeepLink from `AppDestination` to `NavGraphBuilder.composable`.

## Proof Of Work 📹

We can use this tool for testing besides the ADB command: https://www.rapidtables.com/web/tools/html-link-code.html
- `android://home`
- `android://second/789`

https://github.com/nimblehq/android-templates/assets/16315358/770e39fd-917e-4125-b0d2-2ffe913d729f

<img src="https://github.com/nimblehq/android-templates/assets/16315358/6e5a34f8-ad38-4e9a-82b5-ed0b93c49d29" width=300 />
