### PR TITLE
[#500] The "Checkout" step in "bump_version" workflow does not need to set a custom token 

### DIFF
--- a/.cicdtemplate/.github/workflows/bump_version.yml
+++ b/.cicdtemplate/.github/workflows/bump_version.yml
@@ -13,8 +13,8 @@ jobs:
     name: Bump version
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the latest code
-        uses: actions/checkout@v3
+      - name: Checkout source code
+        uses: actions/checkout@v4
 
       - name: Bump version name
         uses: chkfung/android-version-actions@v1.2.1

--- a/.cicdtemplate/.github/workflows/bump_version.yml
+++ b/.cicdtemplate/.github/workflows/bump_version.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bump version name
         uses: chkfung/android-version-actions@v1.2.1

--- a/.cicdtemplate/.github/workflows/deploy_staging_and_production_to_firebase_app_distribution.yml
+++ b/.cicdtemplate/.github/workflows/deploy_staging_and_production_to_firebase_app_distribution.yml
@@ -25,7 +25,7 @@ jobs:
           timezone: Asia/Bangkok
 
       - name: Checkout source code
-        uses: actions/checkout@v2.3.2
+        uses: actions/checkout@v4
 
       - name: Cache Gradle
         uses: actions/cache@v2

--- a/.cicdtemplate/.github/workflows/review_pull_request.yml
+++ b/.cicdtemplate/.github/workflows/review_pull_request.yml
@@ -17,7 +17,7 @@ jobs:
           java-version: '11'
 
       - name: Checkout source code
-        uses: actions/checkout@v2.3.2
+        uses: actions/checkout@v4
 
       - name: Cache Gradle
         uses: actions/cache@v2

--- a/.cicdtemplate/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.cicdtemplate/.github/workflows/run_detekt_and_unit_tests.yml
@@ -28,7 +28,7 @@ jobs:
           timezone: Asia/Bangkok
 
       - name: Checkout source code
-        uses: actions/checkout@v2.3.2
+        uses: actions/checkout@v4
 
       - name: Cache Gradle
         uses: actions/cache@v2

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -13,8 +13,8 @@ jobs:
     name: Bump version
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the latest code
-        uses: actions/checkout@v3
+      - name: Checkout source code
+        uses: actions/checkout@v4
 
       - name: Bump version script
         run: |

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bump version script
         run: |

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - name: Checkout source code
+        uses: actions/checkout@v4
 
       - name: Install Kscript
         run: |

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v3
+      - name: Checkout source code
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -18,7 +18,7 @@ jobs:
           java-version: '11'
 
       - name: Checkout source code
-        uses: actions/checkout@v2.3.2
+        uses: actions/checkout@v4
 
       - name: Cache Gradle
         uses: actions/cache@v2

--- a/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.github/workflows/run_detekt_and_unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2.3.2
+        uses: actions/checkout@v4
 
       - name: Cache Gradle
         uses: actions/cache@v2

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -18,7 +18,7 @@ jobs:
           java-version: '11'
 
       - name: Checkout source code
-        uses: actions/checkout@v2.3.2
+        uses: actions/checkout@v4
 
       - name: Cache Gradle
         uses: actions/cache@v2


### PR DESCRIPTION
closes #500

## What happened 👀

- Removed the token from Bump Version checkout step
- Updated all Checkout calls for consistency

## Insight 📝

We call the Checkout action on every workflow but the step name and version are inconsistent, so they have been updated in this PR too 👀 

## Proof Of Work 📹

[Workflow run](https://github.com/nimblehq/android-templates/actions/runs/6427439143)

[Bump version PR](https://github.com/nimblehq/android-templates/pull/534)
