### PR TITLE
[#521] Fix: The bump_version template workflow does NOT work

### DIFF
--- a/.cicdtemplate/.github/workflows/bump_version.yml
+++ b/.cicdtemplate/.github/workflows/bump_version.yml
@@ -19,10 +19,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bump version name
-        uses: chkfung/android-version-actions@v1.2.1
-        with:
-          gradlePath: app/build.gradle.kts
-          versionName: ${{ github.event.inputs.newVersion }}
+        run: |
+          perl -i -pe 's/ANDROID_VERSION_NAME =(.*)$/ANDROID_VERSION_NAME = "${{ github.event.inputs.newVersion }}"/g' buildSrc/src/main/java/Versions.kt
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
closes #521

## What happened 👀

Replaced the `android-version-action` in `.cicdtemplate/.github/workflows/bump_version.yml` with the Perl command from `.github/workflows/bump_version.yml`

## Insight 📝

N/A

## Proof Of Work 📹

[Generated project PR](https://github.com/ryan-conway/test-bump-version/pull/1)

[Generated project workflow run](https://github.com/ryan-conway/test-bump-version/actions/runs/6429079443)
