### PR TITLE
[#538] Update all workflows to use Java 17

### DIFF
--- a/.cicdtemplate/.github/workflows/deploy_staging_and_production_to_firebase_app_distribution.yml
+++ b/.cicdtemplate/.github/workflows/deploy_staging_and_production_to_firebase_app_distribution.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Set up timezone
         uses: zcong1993/setup-timezone@master

--- a/.cicdtemplate/.github/workflows/review_pull_request.yml
+++ b/.cicdtemplate/.github/workflows/review_pull_request.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.cicdtemplate/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.cicdtemplate/.github/workflows/run_detekt_and_unit_tests.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Set up timezone
         uses: zcong1993/setup-timezone@master

--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -11,11 +11,11 @@ jobs:
     timeout-minutes: 30
     environment: template-compose
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Checkout source code
         uses: actions/checkout@v4


### PR DESCRIPTION
closes #538

## What happened 👀

- Updated all workflows to use Java 17 instead of Java 11

## Insight 📝

N/A

## Proof Of Work 📹

[Generated project PR](https://github.com/ryan-conway/test-bump-version/pull/2)

![image](https://github.com/nimblehq/android-templates/assets/53168251/6898c7ad-f74e-4353-b596-ca989f7f5d8e)

