### PR TITLE
[#543] Add default spacing definition in app dimensions

### DIFF
--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/Item.kt
@@ -33,13 +33,13 @@ fun Item(
         Row {
             Text(
                 modifier = Modifier
-                    .padding(dimensions.spacingNormal)
+                    .padding(dimensions.spacingMedium)
                     .weight(1f),
                 text = uiModel.id
             )
             Text(
                 modifier = Modifier
-                    .padding(dimensions.spacingNormal)
+                    .padding(dimensions.spacingMedium)
                     .weight(2f),
                 text = uiModel.username
             )

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppDimensions.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/theme/AppDimensions.kt
@@ -5,7 +5,14 @@ import androidx.compose.ui.unit.dp
 
 class AppDimensions {
     // Custom dimensions here
-    val spacingNormal = 16.dp
+    val spacing2XSmall = 4.dp
+    val spacingXSmall = 8.dp
+    val spacingSmall = 12.dp
+    val spacingMedium = 16.dp
+    val spacingLarge = 20.dp
+    val spacingXLarge = 24.dp
+    val spacing2XLarge = 28.dp
+    val spacing3XLarge = 32.dp
 }
 
 internal val LocalAppDimensions = staticCompositionLocalOf { AppDimensions() }

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeScreen.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeScreen.kt
@@ -51,7 +51,7 @@ private fun HomeScreenContent(
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(all = dimensions.spacingNormal)
+                .padding(all = dimensions.spacingMedium)
         )
     }
     Timber.d("Result : $uiModels")

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppDimensions.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/theme/AppDimensions.kt
@@ -5,7 +5,14 @@ import androidx.compose.ui.unit.dp
 
 class AppDimensions {
     // Custom dimensions here
-    val spacingNormal = 16.dp
+    val spacing2XSmall = 4.dp
+    val spacingXSmall = 8.dp
+    val spacingSmall = 12.dp
+    val spacingMedium = 16.dp
+    val spacingLarge = 20.dp
+    val spacingXLarge = 24.dp
+    val spacing2XLarge = 28.dp
+    val spacing3XLarge = 32.dp
 }
 
 internal val LocalAppDimensions = staticCompositionLocalOf { AppDimensions() }


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/543

## What happened 👀

We're adopting a new approach. The medium space is defined as 16.dp, with a spacing step of 4.dp. This simplifies both memorization and reference.

```
    val spacing2XSmall = 4.dp
    val spacingXSmall = 8.dp
    val spacingSmall = 12.dp
    val spacingMedium = 16.dp
    val spacingLarge = 20.dp
    val spacingXLarge = 24.dp
    val spacing2XLarge = 28.dp
    val spacing3XLarge = 32.dp
```

## Insight 📝

- Add default spacing definition in `template-compose` and `sample-compose`

## Proof Of Work 📹

N/A
