### PR TITLE
[#535] Add asStateFlow to the StateFlow variables in ViewModel class

### DIFF
--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/base/BaseViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/base/BaseViewModel.kt
@@ -2,7 +2,6 @@ package co.nimblehq.sample.compose.ui.base
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import co.nimblehq.sample.compose.lib.IsLoading
 import co.nimblehq.sample.compose.ui.AppDestination
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
@@ -15,13 +14,13 @@ abstract class BaseViewModel : ViewModel() {
     private var loadingCount: Int = 0
 
     private val _isLoading = MutableStateFlow(false)
-    val isLoading: StateFlow<IsLoading> = _isLoading
+    val isLoading = _isLoading.asStateFlow()
 
     protected val _error = MutableSharedFlow<Throwable>()
-    val error: SharedFlow<Throwable> = _error
+    val error = _error.asSharedFlow()
 
     protected val _navigator = MutableSharedFlow<AppDestination>()
-    val navigator: SharedFlow<AppDestination> = _navigator
+    val navigator = _navigator.asSharedFlow()
 
     /**
      * To show loading manually, should call `hideLoading` after

--- a/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
+++ b/sample-compose/app/src/main/java/co/nimblehq/sample/compose/ui/screens/home/HomeViewModel.kt
@@ -22,10 +22,10 @@ class HomeViewModel @Inject constructor(
 ) : BaseViewModel() {
 
     private val _uiModels = MutableStateFlow<List<UiModel>>(emptyList())
-    val uiModels: StateFlow<List<UiModel>> = _uiModels
+    val uiModels = _uiModels.asStateFlow()
 
     private val _isFirstTimeLaunch = MutableStateFlow(false)
-    val isFirstTimeLaunch: StateFlow<Boolean> = _isFirstTimeLaunch
+    val isFirstTimeLaunch = _isFirstTimeLaunch.asStateFlow()
 
     init {
         getModelsUseCase()

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/base/BaseViewModel.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/base/BaseViewModel.kt
@@ -2,7 +2,6 @@ package co.nimblehq.template.compose.ui.base
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import co.nimblehq.template.compose.lib.IsLoading
 import co.nimblehq.template.compose.ui.AppDestination
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -15,13 +14,13 @@ abstract class BaseViewModel : ViewModel() {
     private var loadingCount: Int = 0
 
     private val _isLoading = MutableStateFlow(false)
-    val isLoading: StateFlow<IsLoading> = _isLoading
+    val isLoading = _isLoading.asStateFlow()
 
     protected val _error = MutableSharedFlow<Throwable>()
-    val error: SharedFlow<Throwable> = _error
+    val error = _error.asSharedFlow()
 
     protected val _navigator = MutableSharedFlow<AppDestination>()
-    val navigator: SharedFlow<AppDestination> = _navigator
+    val navigator = _navigator.asSharedFlow()
 
     /**
      * To show loading manually, should call `hideLoading` after

--- a/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModel.kt
+++ b/template-compose/app/src/main/java/co/nimblehq/template/compose/ui/screens/home/HomeViewModel.kt
@@ -17,7 +17,7 @@ class HomeViewModel @Inject constructor(
 ) : BaseViewModel() {
 
     private val _uiModels = MutableStateFlow<List<UiModel>>(emptyList())
-    val uiModels: StateFlow<List<UiModel>> = _uiModels
+    val uiModels = _uiModels.asStateFlow()
 
     init {
         useCase()


### PR DESCRIPTION
- Closes #535 

## What happened 👀

Currently we can emit values to our `StateFlow` variables by casting them to `MutableStateFlow`. We should update our `StateFlow` declarations to make them read-only

## Insight 📝

- Update our `StateFlow` declarations as follows:
  ```
  private val _uiModels = MutableStateFlow<List<UiModel>>(emptyList())
  val uiModels = _uiModels.asStateFlow()
  ```
- Apply updates to `template-compose` and `sample-compose` ViewModels

## Proof Of Work 📹

The application still runs as usual.


https://github.com/nimblehq/android-templates/assets/32578035/5777eb87-1f95-4d24-a5a5-658e47276247


