### PR TITLE
[#462] Update GitHub workflows to use concurrency

### DIFF
--- a/.cicdtemplate/.github/workflows/bump_version.yml
+++ b/.cicdtemplate/.github/workflows/bump_version.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bump_version:
     name: Bump version

--- a/.cicdtemplate/.github/workflows/review_pull_request.yml
+++ b/.cicdtemplate/.github/workflows/review_pull_request.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [ opened, edited, reopened, synchronize ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   review_pull_request:
     name: Review pull request

--- a/.cicdtemplate/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.cicdtemplate/.github/workflows/run_detekt_and_unit_tests.yml
@@ -10,6 +10,10 @@ on:
       - develop
       - 'release/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_detekt_and_unit_tests:
     name: Run Detekt and unit tests

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bump_version:
     name: Bump version

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   draft_new_release:
     permissions:

--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [ opened, edited, reopened, synchronize ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   review_pull_request:
     name: Review pull request

--- a/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.github/workflows/run_detekt_and_unit_tests.yml
@@ -2,6 +2,10 @@ name: Run Detekt and unit tests
 
 on: push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_detekt_and_unit_tests:
     name: Run Detekt and unit tests

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -5,6 +5,10 @@ on:
     types: [ opened, reopened, synchronize ]
     branches: [ develop ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify_newproject_script:
     name: Verify newproject script


### PR DESCRIPTION
- Closes #462 

## What happened 👀

The [cancel-workflow action added a warning on their README](https://github.com/styfle/cancel-workflow-action) that GitHub now supports concurrency and this workflow might not be needed anymore.

Resource: https://docs.github.com/en/actions/using-jobs/using-concurrency
Sample implementation: https://github.com/nimblehq/rails-templates/pull/398 

## Insight 📝

Add concurrency for all workflows except the following 2:
  - `.github/workflows/publish_docs_to_wiki`
  - `.cicdtemplate/.github/workflows/deploy_staging_and_production_to_firebase_app_distribution.yml`

## Proof Of Work 📹

<img width="1061" alt="Screenshot 2023-10-23 at 5 40 47 PM" src="https://github.com/nimblehq/android-templates/assets/32578035/6cb7ca34-c268-4a7a-b6ec-41344fe4d9e2">


