### PR TITLE
[#491] Enhance CICD workflow for releasing production to Firebase App Distribution

### DIFF
--- a/.cicdtemplate/.github/workflows/deploy_production_to_firebase_app_distribution.yml
+++ b/.cicdtemplate/.github/workflows/deploy_production_to_firebase_app_distribution.yml
@@ -1,11 +1,11 @@
 name: Deploy staging and production to Firebase App Distribution
 
 on:
-  # Trigger the workflow on push action in develop branch.
+  # Trigger the workflow on push action in main branch.
   # So it will trigger when the PR of the feature branch was merged.
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   deploy_staging_and_production_to_firebase_app_distribution:
@@ -56,19 +56,8 @@ jobs:
           name: CodeCoverageReports
           path: app/build/reports/kover/
 
-      - name: Build staging APK
-        run: ./gradlew assembleStagingDebug
-
-      - name: Deploy staging to Firebase
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
-        with:
-          appId: ${{secrets.FIREBASE_APP_ID_STAGING}}
-          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIAL_FILE_CONTENT }}
-          groups: testers
-          file: app/build/outputs/apk/staging/debug/app-staging-debug.apk
-
       - name: Build production APK
-        run: ./gradlew assembleProductionDebug
+        run: ./gradlew assembleProductionRelease
 
       - name: Deploy production to Firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1
@@ -76,4 +65,4 @@ jobs:
           appId: ${{secrets.FIREBASE_APP_ID_PRODUCTION}}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIAL_FILE_CONTENT }}
           groups: testers
-          file: app/build/outputs/apk/production/debug/app-production-debug.apk
+          file: app/build/outputs/apk/production/debug/app-production-release.apk

--- a/.cicdtemplate/.github/workflows/deploy_production_to_firebase_app_distribution.yml
+++ b/.cicdtemplate/.github/workflows/deploy_production_to_firebase_app_distribution.yml
@@ -1,4 +1,4 @@
-name: Deploy staging and production to Firebase App Distribution
+name: Deploy production to Firebase App Distribution
 
 on:
   # Trigger the workflow on push action in main branch.
@@ -8,8 +8,8 @@ on:
       - main
 
 jobs:
-  deploy_staging_and_production_to_firebase_app_distribution:
-    name: Deploy staging and production to Firebase App Distribution
+  deploy_production_to_firebase_app_distribution:
+    name: Deploy production to Firebase App Distribution
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.cicdtemplate/.github/workflows/deploy_staging_to_firebase_app_distribution.yml
+++ b/.cicdtemplate/.github/workflows/deploy_staging_to_firebase_app_distribution.yml
@@ -1,4 +1,4 @@
-name: Deploy staging and production to Firebase App Distribution
+name: Deploy staging to Firebase App Distribution
 
 on:
   # Trigger the workflow on push action in develop branch.
@@ -8,8 +8,8 @@ on:
       - develop
 
 jobs:
-  deploy_staging_and_production_to_firebase_app_distribution:
-    name: Deploy staging and production to Firebase App Distribution
+  deploy_staging_to_firebase_app_distribution:
+    name: Deploy staging to Firebase App Distribution
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.cicdtemplate/.github/workflows/deploy_staging_to_firebase_app_distribution.yml
+++ b/.cicdtemplate/.github/workflows/deploy_staging_to_firebase_app_distribution.yml
@@ -1,0 +1,68 @@
+name: Deploy staging and production to Firebase App Distribution
+
+on:
+  # Trigger the workflow on push action in develop branch.
+  # So it will trigger when the PR of the feature branch was merged.
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy_staging_and_production_to_firebase_app_distribution:
+    name: Deploy staging and production to Firebase App Distribution
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up timezone
+        uses: zcong1993/setup-timezone@master
+        with:
+          timezone: Asia/Bangkok
+
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run Detekt
+        run: ./gradlew detekt
+
+      - name: Archive Detekt reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: DetektReports
+          path: build/reports/detekt/
+
+      - name: Run unit tests with Kover
+        run: ./gradlew koverHtmlReport
+
+      - name: Archive code coverage reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: CodeCoverageReports
+          path: app/build/reports/kover/
+
+      - name: Build staging APK
+        run: ./gradlew assembleStagingDebug
+
+      - name: Deploy staging to Firebase
+        uses: wzieba/Firebase-Distribution-Github-Action@v1
+        with:
+          appId: ${{secrets.FIREBASE_APP_ID_STAGING}}
+          serviceCredentialsFileContent: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIAL_FILE_CONTENT }}
+          groups: testers
+          file: app/build/outputs/apk/staging/debug/app-staging-debug.apk


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/491

## What happened 👀

- Separate 2 CD workflow to deploy `develop` branch on `staging` and `main` branch on `production`
- Update deploy production release app rather than production debug app
- Add creating keystore workflow

## Insight 📝

N/A

## Proof Of Work 📹

Show us the implementation: screenshots, GIFs, etc.
