### PR TITLE
[#525] 1/2 - Create a new workflow to automate the release pull request creation

### DIFF
--- a/.github/workflows/config/changelog-release.json
+++ b/.github/workflows/config/changelog-release.json
@@ -1,0 +1,35 @@
+{
+    "categories": [
+        {
+            "title": "## ✨ Features",
+            "labels": [
+                "type : feature"
+            ],
+            "empty_content": "N/A"
+        },
+        {
+            "title": "## 🐛 Bug fixes",
+            "labels": [
+                "type : bug"
+            ],
+            "empty_content": "N/A"
+        },
+        {
+            "title": "## 🧹 Chores",
+            "labels": [
+                "type : chore"
+            ],
+            "empty_content": "N/A"
+        },
+        {
+            "title": "## Others",
+            "exclude_labels": [
+                "type : feature",
+                "type : bug",
+                "type : chore",
+                "type : release"
+            ]
+        }
+    ],
+    "max_pull_requests": 200
+}

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -1,0 +1,66 @@
+name: Create the Release pull request
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create_release_pr:
+    name: Create the Release pull request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read the current version
+        id: version
+        uses: christian-draeger/read-properties@1.1.1
+        with:
+          path: "version.properties"
+          properties: "templateScriptVersion"
+
+      - name: Find HEAD commit
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: ".github/workflows/config/changelog-release.json"
+          # Listing PRs from the last tag to the HEAD commit
+          toTag: ${{ steps.head.outputs.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create the Release pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=${{ steps.version.outputs.templateScriptVersion }}
+          BASE_BRANCH=main
+          HEAD_BRANCH=release/$VERSION
+
+          # Fetch milestone info
+          gh extension install valeriobelli/gh-milestone
+          MILESTONE=$VERSION
+          MILESTONE_URL=$(gh milestone list --query $MILESTONE --json url --jq ".[0].url")
+
+          # Create the release branch
+          git checkout -b $HEAD_BRANCH
+          git push origin $HEAD_BRANCH
+
+          # Create the pull request
+          gh pr create \
+            --base $BASE_BRANCH \
+            --head $HEAD_BRANCH \
+            --assignee "bot-nimble" \
+            --title "Release - $VERSION" \
+            --label 'type : release' \
+            --milestone $MILESTONE \
+            --body "$MILESTONE_URL
+
+            ${{ steps.changelog.outputs.changelog }}" \


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/525

## What happened 👀

Create a new workflow `create_release_pr.yml` to automate the Release pull request creation:
- to be triggered manually when needed.
- generate the change log as the Release PR content to list all done tasks and PRs from the last `tag` on the main branch to the latest HEAD on the `develop`.
- create the Release PR with the necessary info: title, body, assignee, label, and milestone.

## Insight 📝

- To generate the release change log like our [Release PR](https://github.com/nimblehq/android-templates/pull/550), use https://github.com/mikepenz/release-changelog-builder-action. It helps us generate the change log from a config file, like what we did with https://github.com/release-drafter/release-drafter from https://github.com/nimblehq/android-templates/pull/245. However, https://github.com/mikepenz/release-changelog-builder-action **does not require adding its app to our GitHub organization** and can be reused to generate the change log texts for App Distribution release notes or even create releases like release-drafter.

- To create the pull request by checking out a new release branch from develop, we can NOT use https://github.com/peter-evans/create-pull-request because it [requires stage changes to create PR](https://github.com/peter-evans/create-pull-request/issues/861). Instead, I realized we can create PR using [GitHub CLI](https://cli.github.com/manual/gh_pr_create) 🤩 
  - Before creating the release PR, we must check out a new release branch from the current `develop`.
  - To fetch corresponding `milestone` info (assuming the milestone matches the current version name), while GitHub CLI does not support milestone API officially, we can use an extension called https://github.com/valeriobelli/gh-milestone 🤩 
    This command helps us to get the milestone URL from the milestone name = current version:

	```
	> gh milestone list --query "3.26.0" --json url --jq ".[0].url"  
	https://github.com/luongvo/flutter-survey/milestone/8
	```

## Proof Of Work 📹

A sample generated Release PR for the current `develop` 👉  `main` https://github.com/nimblehq/android-templates/pull/560 🎉 

<img width="827" alt="image" src="https://github.com/nimblehq/android-templates/assets/16315358/92b4b8d9-e9f0-40dc-b42f-69fc02611742">


Run log: https://github.com/nimblehq/android-templates/actions/runs/6971579676/job/18971937503

![](https://pyxis.nymag.com/v1/imgs/5da/56c/3bf66ee5214cbd361855f0c79c1d7d8611-leo-toast-9.2x.h473.w710.gif)
