### PR TITLE
[#490] Add release note for Codemagic CD workflow

### DIFF
--- a/.cicdtemplate/.codemagic/codemagic.yaml
+++ b/.cicdtemplate/.codemagic/codemagic.yaml
@@ -6,6 +6,7 @@ definitions:
     environment:
       groups:
         - firebase_credentials
+      java: 17
     cache:
       cache_paths:
         - $HOME/.gradle/caches
@@ -89,6 +90,7 @@ workflows:
         CM_CLONE_DEPTH: 50
       groups:
         - firebase_credentials
+      java: 17
     scripts:
       - *detekt
       - *unit_test

--- a/.cicdtemplate/.codemagic/codemagic.yaml
+++ b/.cicdtemplate/.codemagic/codemagic.yaml
@@ -97,7 +97,7 @@ workflows:
       - name: Build APK for production
         script: |
           ./gradlew assembleProductionDebug -PversionCode=$BUILD_NUMBER
-      - name: Generating release notes with git commits from the latest tag
+      - name: Generate release notes with git commits from the latest tag
         script: |
           RELEASE_NOTE_CONTENT="$(git log --merges --pretty=%B $(git describe --abbrev=0 --tags)..HEAD | grep "\[")"
           echo "$RELEASE_NOTE_CONTENT" | tee release_notes.txt

--- a/.cicdtemplate/.codemagic/codemagic.yaml
+++ b/.cicdtemplate/.codemagic/codemagic.yaml
@@ -52,13 +52,17 @@ workflows:
       events:
         - push
       branch_patterns:
-        - pattern: develop
+        - pattern: 'develop'
     scripts:
       - *detekt
       - *unit_test
       - name: Build APK for staging
         script: |
           ./gradlew assembleStagingDebug -PversionCode=$BUILD_NUMBER
+      - name: Generating release notes with the latest git commit
+        script: |
+          RELEASE_NOTE_CONTENT="$((git log -1 --merges | grep "\[") | grep . && echo "" || echo $(git log -1 --merges --format=%B))"
+          echo "$RELEASE_NOTE_CONTENT" | tee release_notes.txt
     artifacts:
       - *artifacts_test_report
       - *artifacts_staging_apk
@@ -78,13 +82,23 @@ workflows:
       events:
         - push
       branch_patterns:
-        - pattern: main
+        - pattern: 'main'
+    environment:
+      vars:
+        # Increase the clone depth to 50 to cover all commits from the latest tag
+        CM_CLONE_DEPTH: 50
+      groups:
+        - firebase_credentials
     scripts:
       - *detekt
       - *unit_test
       - name: Build APK for production
         script: |
           ./gradlew assembleProductionDebug -PversionCode=$BUILD_NUMBER
+      - name: Generating release notes with git commits from the latest tag
+        script: |
+          RELEASE_NOTE_CONTENT="$(git log --merges --pretty=%B $(git describe --abbrev=0 --tags)..HEAD | grep "\[")"
+          echo "$RELEASE_NOTE_CONTENT" | tee release_notes.txt
     artifacts:
       - *artifacts_test_report
       - *artifacts_production_apk

--- a/.cicdtemplate/.codemagic/codemagic.yaml
+++ b/.cicdtemplate/.codemagic/codemagic.yaml
@@ -60,7 +60,7 @@ workflows:
       - name: Build APK for staging
         script: |
           ./gradlew assembleStagingDebug -PversionCode=$BUILD_NUMBER
-      - name: Generating release notes with the latest git commit
+      - name: Generate release notes with the latest git commit
         script: |
           RELEASE_NOTE_CONTENT="$((git log -1 --merges | grep "\[") | grep . && echo "" || echo $(git log -1 --merges --format=%B))"
           echo "$RELEASE_NOTE_CONTENT" | tee release_notes.txt

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -54,7 +54,7 @@ workflows:
       events:
         - push
       branch_patterns:
-        - pattern: develop
+        - pattern: 'develop'
     scripts:
       - *detekt_on_template_compose
       - *unit_test_on_template_compose
@@ -62,6 +62,10 @@ workflows:
         working_directory: ./template-compose
         script: |
           ./gradlew assembleStagingDebug -PversionCode=$BUILD_NUMBER
+      - name: Generating release notes with the latest git commit
+        script: |
+          RELEASE_NOTE_CONTENT="$((git log -1 --merges | grep "\[") | grep . && echo "" || echo $(git log -1 --merges --format=%B))"
+          echo "$RELEASE_NOTE_CONTENT" | tee release_notes.txt
     artifacts:
       - *artifacts_template_compose
       - *artifacts_staging_apk
@@ -81,7 +85,13 @@ workflows:
       events:
         - push
       branch_patterns:
-        - pattern: main
+        - pattern: 'main'
+    environment:
+      vars:
+        # Increase the clone depth to 50 to cover all commits from the latest tag
+        CM_CLONE_DEPTH: 50
+      groups:
+        - firebase_credentials
     scripts:
       - *detekt_on_template_compose
       - *unit_test_on_template_compose
@@ -89,6 +99,10 @@ workflows:
         working_directory: ./template-compose
         script: |
           ./gradlew assembleProductionDebug -PversionCode=$BUILD_NUMBER
+      - name: Generating release notes with git commits from the latest tag
+        script: |
+          RELEASE_NOTE_CONTENT="$(git log --merges --pretty=%B $(git describe --abbrev=0 --tags)..HEAD | grep "\[")"
+          echo "$RELEASE_NOTE_CONTENT" | tee release_notes.txt
     artifacts:
       - *artifacts_template_compose
       - *artifacts_production_apk

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -63,7 +63,7 @@ workflows:
         working_directory: ./template-compose
         script: |
           ./gradlew assembleStagingDebug -PversionCode=$BUILD_NUMBER
-      - name: Generating release notes with the latest git commit
+      - name: Generate release notes with the latest git commit
         script: |
           RELEASE_NOTE_CONTENT="$((git log -1 --merges | grep "\[") | grep . && echo "" || echo $(git log -1 --merges --format=%B))"
           echo "$RELEASE_NOTE_CONTENT" | tee release_notes.txt
@@ -101,7 +101,7 @@ workflows:
         working_directory: ./template-compose
         script: |
           ./gradlew assembleProductionDebug -PversionCode=$BUILD_NUMBER
-      - name: Generating release notes with git commits from the latest tag
+      - name: Generate release notes with git commits from the latest tag
         script: |
           RELEASE_NOTE_CONTENT="$(git log --merges --pretty=%B $(git describe --abbrev=0 --tags)..HEAD | grep "\[")"
           echo "$RELEASE_NOTE_CONTENT" | tee release_notes.txt

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -4,9 +4,9 @@ definitions:
     instance_type: mac_mini_m1
     max_build_duration: 30
     environment:
-      java: 17
       groups:
         - firebase_credentials
+      java: 17
     cache:
       cache_paths:
         - $HOME/.gradle/caches
@@ -93,6 +93,7 @@ workflows:
         CM_CLONE_DEPTH: 50
       groups:
         - firebase_credentials
+      java: 17
     scripts:
       - *detekt_on_template_compose
       - *unit_test_on_template_compose

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -4,6 +4,7 @@ definitions:
     instance_type: mac_mini_m1
     max_build_duration: 30
     environment:
+      java: 17
       groups:
         - firebase_credentials
     cache:


### PR DESCRIPTION
- Closes #490 

## What happened 👀

Add command line script to get the commit message to show as the release note on Codemagic CD workflow

## Insight 📝

- For Staging, we use the latest merge commit message
- For Production, we use the latest 50 merge commit messages from the last tag. 


## Proof Of Work 📹

Staging:

![Screenshot 2566-11-09 at 4 56 22 PM](https://github.com/nimblehq/android-templates/assets/12026942/5cf2f40b-53c0-47c4-9e53-7b20486ffe69)

> [!NOTE]
> We need to merge this change to `main` first to see the release note on the Firebase App Distribution.
> But as I test the script, it works correctly in the following image:

![Screenshot 2566-11-10 at 11 09 46 AM](https://github.com/nimblehq/android-templates/assets/12026942/43c4bf5a-7c76-4c86-b8a3-610afc10f34b)