### PR TITLE
[#509] [Script] Add --stacktrace parameter in the command executions to provide a full stack trace for debugging

### DIFF
--- a/scripts/new_project.kts
+++ b/scripts/new_project.kts
@@ -235,14 +235,16 @@ object NewProject {
             "$projectPath${fileSeparator}gradlew",
             "-p",
             "$projectPath",
-            "clean"
+            "clean",
+            "--stacktrace"
         )
         executeCommand(
             "sh",
             "$projectPath${fileSeparator}gradlew",
             "-p",
             "$projectPath${fileSeparator}buildSrc",
-            "clean"
+            "clean",
+            "--stacktrace"
         )
         listOf(".idea", ".gradle", "buildSrc$fileSeparator.gradle", ".git").forEach {
             File("$projectPath$fileSeparator$it")?.let { targetFile ->
@@ -310,7 +312,8 @@ object NewProject {
             "$projectPath${fileSeparator}gradlew",
             "-p",
             "$projectPath",
-            "assembleDebug"
+            "assembleDebug",
+            "--stacktrace"
         )
         showMessage("=> 🚓 Running tests...")
         executeCommand(
@@ -320,7 +323,8 @@ object NewProject {
             "$projectPath",
             ":app:testStagingDebugUnitTest",
             ":data:testDebugUnitTest",
-            ":domain:test"
+            ":domain:test",
+            "--stacktrace"
         )
         showMessage("=> 🚀 Done! The project is ready for development")
     }


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/509

## What happened 👀

Add `--stacktrace` parameter when executing the commands.

## Insight 📝

The error in the PoW occurs when building the project fails.

## Proof Of Work 📹
### Without `--stacktrace`
![image](https://github.com/nimblehq/android-templates/assets/8093908/3f4985bf-f4fc-4889-a67c-b522125ce5c8)
### With `--stacktrace`
![image](https://github.com/nimblehq/android-templates/assets/8093908/6f6d40ec-fc51-4cba-8196-b5613cd3f288)
