### PR TITLE
[#580] Hide Compose androidx.compose.ui.tooling.PreviewActivity from the final release build

### DIFF
--- a/template-compose/app/build.gradle.kts
+++ b/template-compose/app/build.gradle.kts
@@ -143,7 +143,8 @@ dependencies {
     with(Dependencies.Compose) {
         implementation(platform(BOM))
         implementation(UI)
-        implementation(UI_TOOLING)
+        debugImplementation(UI_TOOLING)
+        implementation(UI_TOOLING_PREVIEW)
         implementation(MATERIAL)
         implementation(NAVIGATION)
 

--- a/template-compose/buildSrc/src/main/java/Dependencies.kt
+++ b/template-compose/buildSrc/src/main/java/Dependencies.kt
@@ -11,8 +11,8 @@ object Dependencies {
     object Compose {
         const val BOM = "androidx.compose:compose-bom:${Versions.COMPOSE_BOM}"
         const val UI = "androidx.compose.ui:ui"
-        const val UI_GRAPHICS = "androidx.compose.ui:ui-graphics"
         const val UI_TOOLING = "androidx.compose.ui:ui-tooling"
+        const val UI_TOOLING_PREVIEW = "androidx.compose.ui:ui-tooling-preview"
         const val MATERIAL = "androidx.compose.material:material"
         const val NAVIGATION = "androidx.navigation:navigation-compose:${Versions.COMPOSE_NAVIGATION}"
 


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/580

## What happened 👀

Hide Compose `androidx.compose.ui.tooling.PreviewActivity` from the final release build.

## Insight 📝

According to the latest update https://developer.android.com/develop/ui/compose/tooling:
- `ui-tooling-preview`: Contains the API definitions
- `ui-tooling`: Contains the implementation and can be declared as debugImplementation

## Proof Of Work 📹

No more `Activity (androidx.compose.ui.tooling.PreviewActivity) is not Protected. [android:exported=true]` issue from the new VAPT report ✅

| Before | After |
|--------|--------|
| ![Screenshot 2024-07-18 at 12 01 46](https://github.com/user-attachments/assets/ca12bfe2-e7d1-4fe4-a672-86e3aad83181) | ![Screenshot 2024-07-18 at 12 37 49](https://github.com/user-attachments/assets/d94e4bef-1697-4094-8a7c-95c4aa50004e) | 




