### PR TITLE
[#587] Migrate to latest Kotlin 2.1.0 and Compose Compiler plugin

### DIFF
--- a/sample-compose/app/build.gradle.kts
+++ b/sample-compose/app/build.gradle.kts
@@ -1,8 +1,9 @@
 plugins {
     alias(libs.plugins.android.application)
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kover)
 }
@@ -78,11 +79,6 @@ android {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
-    composeOptions {
-        // TODO Remove this block in https://github.com/nimblehq/android-templates/issues/587
-        kotlinCompilerExtensionVersion = "1.5.3"
-    }
-
     buildFeatures {
         compose = true
         buildConfig = true
@@ -111,10 +107,6 @@ android {
     }
 }
 
-kapt {
-    correctErrorTypes = true
-}
-
 dependencies {
     implementation(projects.data)
     implementation(projects.domain)
@@ -133,7 +125,7 @@ dependencies {
     implementation(libs.androidx.datastore.preferences)
 
     implementation(libs.bundles.hilt)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     implementation(libs.timber)
 

--- a/sample-compose/build.gradle.kts
+++ b/sample-compose/build.gradle.kts
@@ -2,10 +2,11 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.detekt)
     alias(libs.plugins.kover)

--- a/sample-compose/gradle/libs.versions.toml
+++ b/sample-compose/gradle/libs.versions.toml
@@ -12,15 +12,16 @@ composeNavigation = "2.5.3"
 core = "1.10.1"
 datastore = "1.0.0"
 detekt = "1.21.0"
-gradle = "8.1.2"
-hilt = "2.48"
+gradle = "8.8.0"
+hilt = "2.52"
 hiltNavigation = "1.0.0"
 javaxInject = "1"
 junit = "4.13.2"
 kotest = "5.6.2"
-kotlin = "1.9.10"
+kotlin = "2.1.0"
 kotlinxCoroutines = "1.7.1"
 kover = "0.7.3"
+ksp = "2.1.0-1.0.29"
 lifecycle = "2.6.1"
 mockk = "1.13.5"
 moshi = "1.12.0"
@@ -134,11 +135,12 @@ uiTest = [
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradle" }
 android-library = { id = "com.android.library", version.ref = "gradle" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 javaLibrary = { id = "java-library" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin"  }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/sample-compose/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-compose/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jun 28 08:46:12 ICT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/template-compose/app/build.gradle.kts
+++ b/template-compose/app/build.gradle.kts
@@ -2,9 +2,10 @@ import org.jetbrains.kotlin.konan.properties.loadProperties
 
 plugins {
     alias(libs.plugins.android.application)
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kover)
 }
@@ -97,11 +98,6 @@ android {
         buildConfig = true
     }
 
-    // TODO Remove this block in https://github.com/nimblehq/android-templates/issues/587
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.3"
-    }
-
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -124,10 +120,6 @@ android {
     }
 }
 
-kapt {
-    correctErrorTypes = true
-}
-
 dependencies {
     implementation(projects.data)
     implementation(projects.domain)
@@ -143,7 +135,7 @@ dependencies {
     debugImplementation(libs.compose.ui.tooling)
 
     implementation(libs.bundles.hilt)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     implementation(libs.timber)
     debugImplementation(libs.chucker)

--- a/template-compose/build.gradle.kts
+++ b/template-compose/build.gradle.kts
@@ -2,10 +2,11 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.detekt)
     alias(libs.plugins.kover)

--- a/template-compose/gradle/libs.versions.toml
+++ b/template-compose/gradle/libs.versions.toml
@@ -12,15 +12,16 @@ composeNavigation = "2.5.3"
 core = "1.10.1"
 datastore = "1.0.0"
 detekt = "1.21.0"
-gradle = "8.1.2"
-hilt = "2.48"
+gradle = "8.8.0"
+hilt = "2.52"
 hiltNavigation = "1.0.0"
 javaxInject = "1"
 junit = "4.13.2"
 kotest = "5.6.2"
-kotlin = "1.9.10"
+kotlin = "2.1.0"
 kotlinxCoroutines = "1.7.1"
 kover = "0.7.3"
+ksp = "2.1.0-1.0.29"
 lifecycle = "2.6.1"
 mockk = "1.13.5"
 moshi = "1.12.0"
@@ -128,11 +129,12 @@ uiTest = [
 [plugins]
 android-application = { id = "com.android.application", version.ref = "gradle" }
 android-library = { id = "com.android.library", version.ref = "gradle" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 javaLibrary = { id = "java-library" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin"  }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/template-compose/gradle/wrapper/gradle-wrapper.properties
+++ b/template-compose/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Aug 22 12:11:55 ICT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
https://github.com/nimblehq/android-templates/issues/587

## What happened 👀

- Updated `template-compose` and `sample-compose`
  - Updated Kotlin to 2.1.0
  - Updated Gradle to 8.8.0
  - Replaced `composeOptions` with Compose Compiler plugin
  - Replaced Kapt with KSP

## Insight 📝

- Other version updates may be done in a separate PR as they are out of scope 🙇🏻 

## Proof Of Work 📹

Apps still build and run

https://github.com/user-attachments/assets/c54ff9ff-6c93-4d8a-8c89-3a1f05207690




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the build system and dependency versions for improved stability and performance.
	- Streamlined dependency processing to leverage modern tooling and enhance compatibility.
	- These enhancements help ensure a smoother experience with optimized performance and a more robust development foundation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->