### PR TITLE
[Chore] Skip review CIs on draft

### DIFF
--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -2,7 +2,7 @@ name: Review pull request
 
 on:
   pull_request:
-    types: [ opened, edited, reopened, synchronize ]
+    types: [ opened, reopened, synchronize, ready_for_review ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,6 +12,7 @@ jobs:
 
   review_pull_request:
     name: Review pull request
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: template-compose

--- a/.github/workflows/run_detekt_and_unit_tests.yml
+++ b/.github/workflows/run_detekt_and_unit_tests.yml
@@ -1,6 +1,8 @@
 name: Run Detekt and unit tests
 
-on: push
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, ready_for_review ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -9,6 +11,7 @@ concurrency:
 jobs:
   run_detekt_and_unit_tests:
     name: Run Detekt and unit tests
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/verify_newproject_script.yml
+++ b/.github/workflows/verify_newproject_script.yml
@@ -2,7 +2,7 @@ name: Verify newproject script
 
 on:
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    types: [ opened, reopened, synchronize, ready_for_review ]
     branches: [ develop ]
 
 concurrency:
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   verify_newproject_script:
     name: Verify newproject script
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## What happened 👀

- Skip reviewed CIs on draft so it doesn't clutter slack thread

## Insight 📝

N/A


## Proof Of Work 📹

<img width="1088" height="819" alt="Screenshot 2569-07-17 at 13 17 21" src="https://github.com/user-attachments/assets/cb591839-8863-40c1-a566-df1447fb9ed6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated code review and verification now run on pull request updates rather than pushes, using lifecycle events aligned with when a pull request is ready.
  * Draft pull requests are skipped until they are marked ready for review.
  * Review automation no longer triggers on “edited” events, reducing unnecessary runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->